### PR TITLE
[feat] 월별 소비 목표 조회 API 구현하기

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,14 @@
+package com.bbteam.budgetbuddies.domain.category.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.bbteam.budgetbuddies.domain.category.entity.Category;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+	@Query(value = "SELECT c FROM Category AS c WHERE c.isDefault=TRUE OR c.user.id=:id")
+	List<Category> findUserCategoryByUserId(@Param("id") Long id);
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/controller/ConsumptionGoalController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/controller/ConsumptionGoalController.java
@@ -1,0 +1,32 @@
+package com.bbteam.budgetbuddies.domain.consumptiongoal.controller;
+
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseListDto;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.service.ConsumptionGoalService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/consumption-goal")
+public class ConsumptionGoalController {
+	private final ConsumptionGoalService consumptionGoalService;
+
+	@GetMapping("/{userId}")
+	public ResponseEntity<ConsumptionGoalResponseListDto> findUserConsumptionGoal(
+		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date, @PathVariable Long userId) {
+
+		ConsumptionGoalResponseListDto response = consumptionGoalService.findUserConsumptionGoal(userId, date);
+
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/controller/package-info.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/controller/package-info.java
@@ -1,1 +1,0 @@
-package com.bbteam.budgetbuddies.domain.consumptiongoal.controller;

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalResponseDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalResponseDto.java
@@ -1,0 +1,49 @@
+package com.bbteam.budgetbuddies.domain.consumptiongoal.dto;
+
+import java.time.LocalDate;
+
+import com.bbteam.budgetbuddies.domain.category.entity.Category;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.entity.ConsumptionGoal;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ConsumptionGoalResponseDto {
+	private String categoryName;
+	private Long categoryId;
+	private Long goalAmount;
+	private Long consumeAmount;
+	private LocalDate goalMonth;
+
+	@Builder
+	public ConsumptionGoalResponseDto(String categoryName, Long categoryId, Long goalAmount, Long consumeAmount,
+		LocalDate goalMonth) {
+		this.categoryName = categoryName;
+		this.categoryId = categoryId;
+		this.goalAmount = goalAmount;
+		this.consumeAmount = consumeAmount;
+		this.goalMonth = goalMonth;
+	}
+
+	public static ConsumptionGoalResponseDto initializeFromCategoryAndGoalMonth(Category category,
+		LocalDate goalMonth) {
+		return ConsumptionGoalResponseDto.builder()
+			.categoryName(category.getName())
+			.categoryId(category.getId())
+			.goalAmount(0L)
+			.consumeAmount(0L)
+			.goalMonth(goalMonth)
+			.build();
+	}
+
+	public static ConsumptionGoalResponseDto of(ConsumptionGoal consumptionGoal) {
+		return ConsumptionGoalResponseDto.builder()
+			.categoryName(consumptionGoal.getCategory().getName())
+			.categoryId(consumptionGoal.getCategory().getId())
+			.goalAmount(consumptionGoal.getGoalAmount())
+			.consumeAmount(consumptionGoal.getConsumeAmount())
+			.goalMonth(consumptionGoal.getGoalMonth())
+			.build();
+	}
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalResponseListDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalResponseListDto.java
@@ -9,9 +9,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ConsumptionGoalResponseListDto {
-	private List<ConsumptionGoalResponseDto> consumptionGoalResponseDtoList;
+	private List<ConsumptionGoalResponseDto> consumptionGoalList;
 
 	public ConsumptionGoalResponseListDto(List<ConsumptionGoalResponseDto> consumptionGoalResponseDtoList) {
-		this.consumptionGoalResponseDtoList = consumptionGoalResponseDtoList;
+		this.consumptionGoalList = consumptionGoalResponseDtoList;
 	}
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalResponseListDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalResponseListDto.java
@@ -1,0 +1,17 @@
+package com.bbteam.budgetbuddies.domain.consumptiongoal.dto;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ConsumptionGoalResponseListDto {
+	private List<ConsumptionGoalResponseDto> consumptionGoalResponseDtoList;
+
+	public ConsumptionGoalResponseListDto(List<ConsumptionGoalResponseDto> consumptionGoalResponseDtoList) {
+		this.consumptionGoalResponseDtoList = consumptionGoalResponseDtoList;
+	}
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/package-info.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/package-info.java
@@ -1,1 +1,0 @@
-package com.bbteam.budgetbuddies.domain.consumptiongoal.dto;

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/repository/ConsumptionGoalRepository.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/repository/ConsumptionGoalRepository.java
@@ -1,0 +1,14 @@
+package com.bbteam.budgetbuddies.domain.consumptiongoal.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.bbteam.budgetbuddies.domain.consumptiongoal.entity.ConsumptionGoal;
+
+public interface ConsumptionGoalRepository extends JpaRepository<ConsumptionGoal, Long> {
+	@Query(value = "SELECT cg FROM ConsumptionGoal AS cg WHERE cg.user.id = :userId AND cg.goalMonth = :goalMonth")
+	List<ConsumptionGoal> findConsumptionGoalByUserIdAndGoalMonth(Long userId, LocalDate goalMonth);
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/repository/package-info.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/repository/package-info.java
@@ -1,1 +1,0 @@
-package com.bbteam.budgetbuddies.domain.consumptiongoal.repository;

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalService.java
@@ -1,12 +1,13 @@
 package com.bbteam.budgetbuddies.domain.consumptiongoal.service;
 
 import java.time.LocalDate;
-import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.bbteam.budgetbuddies.domain.category.entity.Category;
 import com.bbteam.budgetbuddies.domain.category.repository.CategoryRepository;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseDto;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseListDto;
@@ -20,31 +21,39 @@ public class ConsumptionGoalService {
 	private final ConsumptionGoalRepository consumptionGoalRepository;
 	private final CategoryRepository categoryRepository;
 
-	public ConsumptionGoalResponseListDto findUserConsumptionGoal(Long userId, LocalDate localDate) {
-		final LocalDate goalMonth = LocalDate.of(localDate.getYear(), localDate.getMonth(), 1);
+	public ConsumptionGoalResponseListDto findUserConsumptionGoal(Long userId, LocalDate date) {
+		LocalDate goalMonth = date.withDayOfMonth(1);
+		Map<Long, ConsumptionGoalResponseDto> goalMap = initializeGoalMap(userId, goalMonth);
 
-		Map<Long, ConsumptionGoalResponseDto> consumptionGoalResponseDtoMap = categoryRepository
-			.findUserCategoryByUserId(userId)
+		updateGoalMapWithPreviousMonth(userId, goalMonth, goalMap);
+		updateGoalMapWithCurrentMonth(userId, goalMonth, goalMap);
+
+		return new ConsumptionGoalResponseListDto(new ArrayList<>(goalMap.values()));
+	}
+
+	private Map<Long, ConsumptionGoalResponseDto> initializeGoalMap(Long userId, LocalDate goalMonth) {
+		return categoryRepository.findUserCategoryByUserId(userId)
 			.stream()
-			.map(c -> ConsumptionGoalResponseDto.initializeFromCategoryAndGoalMonth(c, goalMonth))
-			.collect(Collectors.toMap(ConsumptionGoalResponseDto::getCategoryId, c -> c));
+			.collect(Collectors.toMap(
+				Category::getId,
+				category -> ConsumptionGoalResponseDto.initializeFromCategoryAndGoalMonth(category, goalMonth)
+			));
+	}
 
-		List<ConsumptionGoalResponseDto> lastMonthConsumptionGoalList = consumptionGoalRepository
-			.findConsumptionGoalByUserIdAndGoalMonth(userId, goalMonth.minusMonths(1))
-			.stream().map(ConsumptionGoalResponseDto::of).toList();
+	private void updateGoalMapWithPreviousMonth(Long userId, LocalDate goalMonth,
+		Map<Long, ConsumptionGoalResponseDto> goalMap) {
+		updateGoalMap(userId, goalMonth.minusMonths(1), goalMap);
+	}
 
-		for (ConsumptionGoalResponseDto cgd : lastMonthConsumptionGoalList) {
-			consumptionGoalResponseDtoMap.put(cgd.getCategoryId(), cgd);
-		}
+	private void updateGoalMapWithCurrentMonth(Long userId, LocalDate goalMonth,
+		Map<Long, ConsumptionGoalResponseDto> goalMap) {
+		updateGoalMap(userId, goalMonth, goalMap);
+	}
 
-		List<ConsumptionGoalResponseDto> consumptionGoalList = consumptionGoalRepository
-			.findConsumptionGoalByUserIdAndGoalMonth(userId, goalMonth)
-			.stream().map(ConsumptionGoalResponseDto::of).toList();
-
-		for (ConsumptionGoalResponseDto cgd : consumptionGoalList) {
-			consumptionGoalResponseDtoMap.put(cgd.getCategoryId(), cgd);
-		}
-
-		return new ConsumptionGoalResponseListDto(consumptionGoalResponseDtoMap.values().stream().toList());
+	private void updateGoalMap(Long userId, LocalDate month, Map<Long, ConsumptionGoalResponseDto> goalMap) {
+		consumptionGoalRepository.findConsumptionGoalByUserIdAndGoalMonth(userId, month)
+			.stream()
+			.map(ConsumptionGoalResponseDto::of)
+			.forEach(goal -> goalMap.put(goal.getCategoryId(), goal));
 	}
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalService.java
@@ -1,0 +1,50 @@
+package com.bbteam.budgetbuddies.domain.consumptiongoal.service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.bbteam.budgetbuddies.domain.category.repository.CategoryRepository;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseDto;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseListDto;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.repository.ConsumptionGoalRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ConsumptionGoalService {
+	private final ConsumptionGoalRepository consumptionGoalRepository;
+	private final CategoryRepository categoryRepository;
+
+	public ConsumptionGoalResponseListDto findUserConsumptionGoal(Long userId, LocalDate localDate) {
+		final LocalDate goalMonth = LocalDate.of(localDate.getYear(), localDate.getMonth(), 1);
+
+		Map<Long, ConsumptionGoalResponseDto> consumptionGoalResponseDtoMap = categoryRepository
+			.findUserCategoryByUserId(userId)
+			.stream()
+			.map(c -> ConsumptionGoalResponseDto.initializeFromCategoryAndGoalMonth(c, goalMonth))
+			.collect(Collectors.toMap(ConsumptionGoalResponseDto::getCategoryId, c -> c));
+
+		List<ConsumptionGoalResponseDto> lastMonthConsumptionGoalList = consumptionGoalRepository
+			.findConsumptionGoalByUserIdAndGoalMonth(userId, goalMonth.minusMonths(1))
+			.stream().map(ConsumptionGoalResponseDto::of).toList();
+
+		for (ConsumptionGoalResponseDto cgd : lastMonthConsumptionGoalList) {
+			consumptionGoalResponseDtoMap.put(cgd.getCategoryId(), cgd);
+		}
+
+		List<ConsumptionGoalResponseDto> consumptionGoalList = consumptionGoalRepository
+			.findConsumptionGoalByUserIdAndGoalMonth(userId, goalMonth)
+			.stream().map(ConsumptionGoalResponseDto::of).toList();
+
+		for (ConsumptionGoalResponseDto cgd : consumptionGoalList) {
+			consumptionGoalResponseDtoMap.put(cgd.getCategoryId(), cgd);
+		}
+
+		return new ConsumptionGoalResponseListDto(consumptionGoalResponseDtoMap.values().stream().toList());
+	}
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/package-info.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/package-info.java
@@ -1,1 +1,0 @@
-package com.bbteam.budgetbuddies.domain.consumptiongoal.service;

--- a/src/test/java/com/bbteam/budgetbuddies/domain/category/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/bbteam/budgetbuddies/domain/category/repository/CategoryRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.bbteam.budgetbuddies.domain.category.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.bbteam.budgetbuddies.domain.category.entity.Category;
+import com.bbteam.budgetbuddies.domain.user.entity.User;
+import com.bbteam.budgetbuddies.domain.user.repository.UserRepository;
+
+@DisplayName("Category 레포지토리 테스트의 ")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CategoryRepositoryTest {
+	@Autowired
+	UserRepository userRepository;
+	@Autowired
+	CategoryRepository categoryRepository;
+
+	@Test
+	@DisplayName("Custom 카테고리와 Base 카테고리 조회 성공")
+	void findUserCategoryByUserIdTest_Success() {
+		User user = userRepository.save(User.builder()
+			.email("email")
+			.age(24)
+			.name("name")
+			.phoneNumber("010-1234-5678")
+			.build());
+
+		User otherUser = userRepository.save(User.builder()
+			.email("email2")
+			.age(25)
+			.name("name2")
+			.phoneNumber("010-2345-5678")
+			.build());
+
+		Category defaultCategory = categoryRepository.save(Category.builder()
+			.name("디폴트 카테고리")
+			.user(null)
+			.isDefault(true)
+			.build());
+
+		Category userCategory = categoryRepository.save(Category.builder()
+			.name("유저 카테고리")
+			.user(user)
+			.isDefault(false)
+			.build());
+
+		categoryRepository.save(Category.builder()
+			.name("다른 유저 카테고리")
+			.user(otherUser)
+			.isDefault(false)
+			.build());
+
+		// when
+		List<Category> result = categoryRepository.findUserCategoryByUserId(user.getId());
+
+		// then
+		assertThat(result).usingRecursiveComparison().isEqualTo(List.of(defaultCategory, userCategory));
+	}
+}

--- a/src/test/java/com/bbteam/budgetbuddies/domain/consumptiongoal/repository/ConsumptionGoalRepositoryTest.java
+++ b/src/test/java/com/bbteam/budgetbuddies/domain/consumptiongoal/repository/ConsumptionGoalRepositoryTest.java
@@ -29,81 +29,68 @@ class ConsumptionGoalRepositoryTest {
 	CategoryRepository categoryRepository;
 
 	@Test
-	@DisplayName("유저 아이디와 LocalDate를 통해 GoalConsumption 조회 성공")
+	@DisplayName("유저 아이디와 goalMonth를 통해 GoalConsumption 조회 성공")
 	void findConsumptionGoalByUserIdAndGoalMonth_Success() {
+		// given
+		// 목표 달
 		LocalDate goalMonth = LocalDate.of(2024, 07, 01);
 
-		User user = userRepository.save(User.builder()
-			.email("email")
-			.age(24)
-			.name("name")
-			.phoneNumber("010-1234-5678")
+		User mainUser = userRepository.save(
+			User.builder().email("email").age(24).name("name").phoneNumber("010-1234-5678").build());
+
+		Category defaultCategory = categoryRepository.save(
+			Category.builder().name("디폴트 카테고리").user(null).isDefault(true).build());
+
+		Category userCategory = categoryRepository.save(
+			Category.builder().name("유저 카테고리").user(mainUser).isDefault(false).build());
+
+		ConsumptionGoal defaultCategoryConsumptionGoal = consumptionGoalRepository.save(ConsumptionGoal.builder()
+			.goalAmount(1L)
+			.consumeAmount(1L)
+			.user(mainUser)
+			.goalMonth(goalMonth)
+			.category(defaultCategory)
 			.build());
 
-		User otherUser = userRepository.save(User.builder()
-			.email("email2")
-			.age(24)
-			.name("name2")
-			.phoneNumber("010-1567-5678")
+		ConsumptionGoal userCategoryConsumptionGoal = consumptionGoalRepository.save(ConsumptionGoal.builder()
+			.goalAmount(1L)
+			.consumeAmount(1L)
+			.user(mainUser)
+			.goalMonth(goalMonth)
+			.category(userCategory)
 			.build());
 
-		Category defaultCategory = categoryRepository.save(Category.builder()
-			.name("디폴트 카테고리")
-			.user(null)
-			.isDefault(true)
-			.build());
+		setUnselectedConsumptionGoal(mainUser, goalMonth, defaultCategory);
 
-		Category userCategory = categoryRepository.save(Category.builder()
-			.name("유저 카테고리")
-			.user(user)
-			.isDefault(false)
-			.build());
+		// when
+		List<ConsumptionGoal> result = consumptionGoalRepository.findConsumptionGoalByUserIdAndGoalMonth(mainUser.getId(),
+			goalMonth);
 
-		ConsumptionGoal defaultCategoryConsumptionGoal = consumptionGoalRepository.save(
+		// then
+		assertThat(result).usingRecursiveComparison()
+			.isEqualTo(List.of(defaultCategoryConsumptionGoal, userCategoryConsumptionGoal));
+	}
+
+	private void setUnselectedConsumptionGoal(User mainUser, LocalDate goalMonth, Category defaultCategory) {
+		User otherUser = userRepository.save(
+			User.builder().email("email2").age(24).name("name2").phoneNumber("010-1567-5678").build());
+
+		ConsumptionGoal lastMonthDefaultCategoryConsumptionGoal = consumptionGoalRepository.save(
 			ConsumptionGoal.builder()
 				.goalAmount(1L)
 				.consumeAmount(1L)
-				.user(user)
-				.goalMonth(goalMonth)
-				.category(defaultCategory)
-				.build()
-		);
-
-		ConsumptionGoal customCategoryConsumptionGoal = consumptionGoalRepository.save(
-			ConsumptionGoal.builder()
-				.goalAmount(1L)
-				.consumeAmount(1L)
-				.user(user)
-				.goalMonth(goalMonth)
-				.category(userCategory)
-				.build()
-		);
-
-		consumptionGoalRepository.save(
-			ConsumptionGoal.builder()
-				.goalAmount(1L)
-				.consumeAmount(1L)
-				.user(user)
+				.user(mainUser)
 				.goalMonth(goalMonth.minusMonths(1))
 				.category(defaultCategory)
-				.build()
-		);
+				.build());
 
-		consumptionGoalRepository.save(
+		ConsumptionGoal otherUserDefaultCategoryConsumptionGoal = consumptionGoalRepository.save(
 			ConsumptionGoal.builder()
 				.goalAmount(1L)
 				.consumeAmount(1L)
 				.user(otherUser)
 				.goalMonth(goalMonth)
 				.category(defaultCategory)
-				.build()
-		);
-
-		List<ConsumptionGoal> result = consumptionGoalRepository.findConsumptionGoalByUserIdAndGoalMonth(user.getId(),
-			goalMonth);
-
-		assertThat(result).usingRecursiveComparison()
-			.isEqualTo(
-				List.of(defaultCategoryConsumptionGoal, customCategoryConsumptionGoal));
+				.build());
 	}
 }

--- a/src/test/java/com/bbteam/budgetbuddies/domain/consumptiongoal/repository/ConsumptionGoalRepositoryTest.java
+++ b/src/test/java/com/bbteam/budgetbuddies/domain/consumptiongoal/repository/ConsumptionGoalRepositoryTest.java
@@ -1,0 +1,109 @@
+package com.bbteam.budgetbuddies.domain.consumptiongoal.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.bbteam.budgetbuddies.domain.category.entity.Category;
+import com.bbteam.budgetbuddies.domain.category.repository.CategoryRepository;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.entity.ConsumptionGoal;
+import com.bbteam.budgetbuddies.domain.user.entity.User;
+import com.bbteam.budgetbuddies.domain.user.repository.UserRepository;
+
+@DisplayName("ConsumptionGoal 레포지토리 테스트의 ")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ConsumptionGoalRepositoryTest {
+	@Autowired
+	ConsumptionGoalRepository consumptionGoalRepository;
+	@Autowired
+	UserRepository userRepository;
+	@Autowired
+	CategoryRepository categoryRepository;
+
+	@Test
+	@DisplayName("유저 아이디와 LocalDate를 통해 GoalConsumption 조회 성공")
+	void findConsumptionGoalByUserIdAndGoalMonth_Success() {
+		LocalDate goalMonth = LocalDate.of(2024, 07, 01);
+
+		User user = userRepository.save(User.builder()
+			.email("email")
+			.age(24)
+			.name("name")
+			.phoneNumber("010-1234-5678")
+			.build());
+
+		User otherUser = userRepository.save(User.builder()
+			.email("email2")
+			.age(24)
+			.name("name2")
+			.phoneNumber("010-1567-5678")
+			.build());
+
+		Category defaultCategory = categoryRepository.save(Category.builder()
+			.name("디폴트 카테고리")
+			.user(null)
+			.isDefault(true)
+			.build());
+
+		Category userCategory = categoryRepository.save(Category.builder()
+			.name("유저 카테고리")
+			.user(user)
+			.isDefault(false)
+			.build());
+
+		ConsumptionGoal defaultCategoryConsumptionGoal = consumptionGoalRepository.save(
+			ConsumptionGoal.builder()
+				.goalAmount(1L)
+				.consumeAmount(1L)
+				.user(user)
+				.goalMonth(goalMonth)
+				.category(defaultCategory)
+				.build()
+		);
+
+		ConsumptionGoal customCategoryConsumptionGoal = consumptionGoalRepository.save(
+			ConsumptionGoal.builder()
+				.goalAmount(1L)
+				.consumeAmount(1L)
+				.user(user)
+				.goalMonth(goalMonth)
+				.category(userCategory)
+				.build()
+		);
+
+		consumptionGoalRepository.save(
+			ConsumptionGoal.builder()
+				.goalAmount(1L)
+				.consumeAmount(1L)
+				.user(user)
+				.goalMonth(goalMonth.minusMonths(1))
+				.category(defaultCategory)
+				.build()
+		);
+
+		consumptionGoalRepository.save(
+			ConsumptionGoal.builder()
+				.goalAmount(1L)
+				.consumeAmount(1L)
+				.user(otherUser)
+				.goalMonth(goalMonth)
+				.category(defaultCategory)
+				.build()
+		);
+
+		List<ConsumptionGoal> result = consumptionGoalRepository.findConsumptionGoalByUserIdAndGoalMonth(user.getId(),
+			goalMonth);
+
+		assertThat(result).usingRecursiveComparison()
+			.isEqualTo(
+				List.of(defaultCategoryConsumptionGoal, customCategoryConsumptionGoal));
+	}
+}

--- a/src/test/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceTest.java
+++ b/src/test/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceTest.java
@@ -22,7 +22,7 @@ import com.bbteam.budgetbuddies.domain.consumptiongoal.entity.ConsumptionGoal;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.repository.ConsumptionGoalRepository;
 import com.bbteam.budgetbuddies.domain.user.entity.User;
 
-// TODO 꺠끗하게 작성하기;
+// TODO 깨끗하게 작성하기;
 @DisplayName("ConsumptionGoal 테스트의 ")
 @ExtendWith(MockitoExtension.class)
 class ConsumptionGoalServiceTest {
@@ -120,6 +120,6 @@ class ConsumptionGoalServiceTest {
 		ConsumptionGoalResponseListDto result = consumptionGoalService.findUserConsumptionGoal(user.getId(),
 			goalMonth.plusDays(2));
 
-		assertThat(result.getConsumptionGoalResponseDtoList()).usingRecursiveComparison().isEqualTo(expected);
+		assertThat(result.getConsumptionGoalList()).usingRecursiveComparison().isEqualTo(expected);
 	}
 }

--- a/src/test/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceTest.java
+++ b/src/test/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceTest.java
@@ -1,0 +1,125 @@
+package com.bbteam.budgetbuddies.domain.consumptiongoal.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.bbteam.budgetbuddies.domain.category.entity.Category;
+import com.bbteam.budgetbuddies.domain.category.repository.CategoryRepository;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseDto;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseListDto;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.entity.ConsumptionGoal;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.repository.ConsumptionGoalRepository;
+import com.bbteam.budgetbuddies.domain.user.entity.User;
+
+// TODO 꺠끗하게 작성하기;
+@DisplayName("ConsumptionGoal 테스트의 ")
+@ExtendWith(MockitoExtension.class)
+class ConsumptionGoalServiceTest {
+	@InjectMocks
+	private ConsumptionGoalService consumptionGoalService;
+
+	@Mock
+	private CategoryRepository categoryRepository;
+	@Mock
+	private ConsumptionGoalRepository consumptionGoalRepository;
+
+	@Test
+	@DisplayName("findUserConsumptionGoal 성공")
+	void findUserConsumptionGoal_success() {
+		LocalDate goalMonth = LocalDate.of(2024, 07, 01);
+
+		User user = Mockito.spy(User.builder()
+			.email("email")
+			.age(24)
+			.name("name")
+			.phoneNumber("010-1234-5678")
+			.build());
+		given(user.getId()).willReturn(-1L);
+
+		Category defaultCategory = Mockito.spy(Category.builder()
+			.name("디폴트 카테고리")
+			.user(null)
+			.isDefault(true)
+			.build());
+		given(defaultCategory.getId()).willReturn(-1L);
+
+		Category userCategory = Mockito.spy(Category.builder()
+			.name("유저 카테고리")
+			.user(user)
+			.isDefault(false)
+			.build());
+		given(userCategory.getId()).willReturn(-2L);
+
+		Category userCategory2 = Mockito.spy(Category.builder()
+			.name("유저 카테고리2")
+			.user(user)
+			.isDefault(false)
+			.build());
+		given(userCategory2.getId()).willReturn(-3L);
+
+		Category userCategory3 = Mockito.spy(Category.builder()
+			.name("유저 카테고리3")
+			.user(user)
+			.isDefault(false)
+			.build());
+		given(userCategory3.getId()).willReturn(-4L);
+
+		given(categoryRepository.findUserCategoryByUserId(user.getId()))
+			.willReturn(List.of(defaultCategory, userCategory, userCategory2, userCategory3));
+
+		// default
+		ConsumptionGoal consumptionGoal1 = ConsumptionGoal.builder()
+			.goalAmount(1L)
+			.consumeAmount(1L)
+			.user(user)
+			.category(defaultCategory)
+			.goalMonth(goalMonth)
+			.build();
+
+		// custom
+		ConsumptionGoal consumptionGoal2 = ConsumptionGoal.builder()
+			.goalAmount(1L)
+			.consumeAmount(1L)
+			.user(user)
+			.category(userCategory2)
+			.goalMonth(goalMonth)
+			.build();
+
+		// 1달 전
+		ConsumptionGoal consumptionGoal3 = ConsumptionGoal.builder()
+			.goalAmount(1L)
+			.consumeAmount(1L)
+			.user(user)
+			.category(userCategory2)
+			.goalMonth(goalMonth.withMonth(1))
+			.build();
+
+		given(consumptionGoalRepository.findConsumptionGoalByUserIdAndGoalMonth(user.getId(), goalMonth)).willReturn(
+			List.of(consumptionGoal1, consumptionGoal2));
+
+		given(consumptionGoalRepository.findConsumptionGoalByUserIdAndGoalMonth(user.getId(), goalMonth.minusMonths(1)))
+			.willReturn(List.of(consumptionGoal3));
+
+		List<ConsumptionGoalResponseDto> expected = List.of(
+			ConsumptionGoalResponseDto.of(consumptionGoal1), // default
+			ConsumptionGoalResponseDto.initializeFromCategoryAndGoalMonth(userCategory, goalMonth), // 1
+			ConsumptionGoalResponseDto.of(consumptionGoal2), // 2
+			ConsumptionGoalResponseDto.initializeFromCategoryAndGoalMonth(userCategory3, goalMonth)); // 3
+
+		ConsumptionGoalResponseListDto result = consumptionGoalService.findUserConsumptionGoal(user.getId(),
+			goalMonth.plusDays(2));
+
+		assertThat(result.getConsumptionGoalResponseDtoList()).usingRecursiveComparison().isEqualTo(expected);
+	}
+}


### PR DESCRIPTION
## 개요
> 특정 달에 해당하는 소비 목표 조회 API 구현하기
- 사용자가 따로 조정하지 않았다면, 전달에 설정했던 목표 금액이 그대로 설정
- [x] 전체 카테고리(Custom Category + Base Category) 불러오기
- [x] Response DTO 초기화 모든 금액 0원으로
- [x] **유저+날짜**를 통해서 소비 목표 가져오기
    - [x] userId + LocalDate.minusMonths(1) → 지난 달
    - [x] userId + LocalDate → 이번 달
    - 날짜 형식 : `yyyy-MM-01`
- [x] 카테고리 ID에 매핑되는 Response DTO를 초기화
    - [x] 특정 달 - 1 소비 목표들로 초기화
    - [x] 특정 달 소비 목표들로 초기화
- ResponseDTO에는 지난 달에도 목표가 없는 카테고리, 지난 달 목표, 이번달 목표를 가지게 됨

## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [x] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.

## ETC
- Service 계층에 인터페이스 미적용
- 응답 메시지 통일시키지 못함
- 머지 된후 이슈를 새로 파서 적용 후 풀리퀘 요청할 예정
