### PR TITLE
[feat] 또래나이와 성별 조회 API

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/controller/ConsumptionGoalController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/controller/ConsumptionGoalController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseListDto;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.PeerInfoResponseDTO;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.TopGoalCategoryResponseDTO;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.service.ConsumptionGoalService;
 
@@ -56,4 +57,21 @@ public class ConsumptionGoalController {
 
 		return ResponseEntity.ok(response);
 	}
+
+	@Operation(summary = "또래나이와 성별 조회 API", description = "또래나이와 성별을 조회하는 API 입니다.")
+	@ApiResponses(value = {@ApiResponse(responseCode = "COMMON200", description = "OK, 성공")})
+	@Parameters({
+		@Parameter(name = "userId", description = "로그인 한 유저 아이디"),
+		@Parameter(name = "peerAgeStart", description = "또래나이 시작 범위"),
+		@Parameter(name = "peerAgeEnd", description = "또래나이 끝 범위"),
+		@Parameter(name = "peerGender", description = "또래 성별")})
+	@GetMapping("/peer-info")
+	public ResponseEntity<?> getPeerInfo(@RequestParam(name = "userId") Long userId,
+		@RequestParam(name = "peerAgeStart", defaultValue = "0") int peerAgeStart,
+		@RequestParam(name = "peerAgeEnd", defaultValue = "0") int peerAgeEnd,
+		@RequestParam(name = "peerGender", defaultValue = "none") String peerGender) {
+		PeerInfoResponseDTO response = consumptionGoalService.getPeerInfo(userId, peerAgeStart, peerAgeEnd, peerGender);
+		return ResponseEntity.ok(response);
+	}
+
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/converter/PeerInfoConverter.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/converter/PeerInfoConverter.java
@@ -1,0 +1,16 @@
+package com.bbteam.budgetbuddies.domain.consumptiongoal.converter;
+
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.PeerInfoResponseDTO;
+import com.bbteam.budgetbuddies.enums.Gender;
+
+public class PeerInfoConverter {
+
+	public static PeerInfoResponseDTO fromEntity(int peerAgeStart, int peerAgeEnd, Gender peerGender) {
+
+		return PeerInfoResponseDTO.builder()
+			.peerAgeStart(peerAgeStart)
+			.peerAgeEnd(peerAgeEnd)
+			.peerGender(peerGender.name())
+			.build();
+	}
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/PeerInfoResponseDTO.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/PeerInfoResponseDTO.java
@@ -1,0 +1,19 @@
+package com.bbteam.budgetbuddies.domain.consumptiongoal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PeerInfoResponseDTO {
+
+	private int peerAgeStart;
+
+	private int peerAgeEnd;
+
+	private String peerGender;
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseListDto;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.PeerInfoResponseDTO;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.TopGoalCategoryResponseDTO;
 
 @Service
@@ -15,4 +16,6 @@ public interface ConsumptionGoalService {
 		String peerGender);
 
 	ConsumptionGoalResponseListDto findUserConsumptionGoal(Long userId, LocalDate date);
+
+	PeerInfoResponseDTO getPeerInfo(Long userId, int peerAgeStart, int peerAgeEnd, String peerGender);
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceImpl.java
@@ -13,9 +13,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.bbteam.budgetbuddies.domain.category.entity.Category;
 import com.bbteam.budgetbuddies.domain.category.repository.CategoryRepository;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.converter.PeerInfoConverter;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.converter.TopCategoryConverter;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseDto;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseListDto;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.PeerInfoResponseDTO;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.TopGoalCategoryResponseDTO;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.entity.ConsumptionGoal;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.repository.ConsumptionGoalRepository;
@@ -60,6 +62,17 @@ public class ConsumptionGoalServiceImpl implements ConsumptionGoalService {
 		updateGoalMapWithCurrentMonth(userId, goalMonth, goalMap);
 
 		return new ConsumptionGoalResponseListDto(new ArrayList<>(goalMap.values()));
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public PeerInfoResponseDTO getPeerInfo(Long userId, int peerAgeS, int peerAgeE, String peerG) {
+
+		User user = findUserById(userId);
+
+		checkPeerInfo(user, peerAgeS, peerAgeE, peerG);
+
+		return PeerInfoConverter.fromEntity(peerAgeStart, peerAgeEnd, peerGender);
 	}
 
 	private User findUserById(Long userId) {

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceImpl.java
@@ -111,7 +111,10 @@ public class ConsumptionGoalServiceImpl implements ConsumptionGoalService {
 			peerAgeEnd = 28;
 		} else if (userAge >= 29) {
 			peerAgeStart = 29;
-			peerAgeEnd = 100;
+			peerAgeEnd = 99;
+		}else{
+			peerAgeStart = 0;
+			peerAgeEnd = 19;
 		}
 	}
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

#19 
- userId를 통해 로그인 한 유저 정보를 바탕으로 또래 나이와 성별 지정
- 또래 시작 나이와 끝 나이, 성별을 입력 받은 다른 또래의 정보로 응답

## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
