### PR TITLE
[feat] 소비 목표 수정하기 api 구현

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/controller/ConsumptionGoalApi.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/controller/ConsumptionGoalApi.java
@@ -1,0 +1,43 @@
+package com.bbteam.budgetbuddies.domain.consumptiongoal.controller;
+
+import java.time.LocalDate;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalListRequestDto;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseListDto;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+public interface ConsumptionGoalApi {
+	@Operation(summary = "또래들이 가장 큰 계획을 세운 카테고리 조회 API", description = "특정 사용자의 소비 목표 카테고리별 소비 목표 금액을 조회하는 API 입니다.")
+	@ApiResponses(value = {@ApiResponse(responseCode = "COMMON200", description = "OK, 성공")})
+	@Parameters({@Parameter(name = "top", description = "가장 큰 목표를 세운 카테고리의 개수를 지정합니다. (기본값은 5입니다)"),
+		@Parameter(name = "userId", description = "로그인 한 유저 아이디"),
+		@Parameter(name = "peerAgeStart", description = "또래나이 시작 범위"),
+		@Parameter(name = "peerAgeEnd", description = "또래나이 끝 범위"),
+		@Parameter(name = "peerGender", description = "또래 성별")})
+	ResponseEntity<?> getTopGoalCategories(@RequestParam(name = "top", defaultValue = "5") int top, Long userId,
+		int peerAgeStart, int peerAgeEnd, String peerGender);
+
+	@Operation(summary = "소비 목표 조회 API", description = "date={yyyy-MM-dd} 형식의 query string을 통해서 사용자의 목표 달을 조회하는 API 입니다.")
+	@Parameters({@Parameter(name = "date", description = "yyyy-MM-dd 형식으로 목표 달의 소비를 조회")})
+	ResponseEntity<ConsumptionGoalResponseListDto> findUserConsumptionGoal(LocalDate date, Long userId);
+
+	@Operation(summary = "또래나이와 성별 조회 API", description = "또래나이와 성별을 조회하는 API 입니다.")
+	@ApiResponses(value = {@ApiResponse(responseCode = "COMMON200", description = "OK, 성공")})
+	@Parameters({@Parameter(name = "userId", description = "로그인 한 유저 아이디"),
+		@Parameter(name = "peerAgeStart", description = "또래나이 시작 범위"),
+		@Parameter(name = "peerAgeEnd", description = "또래나이 끝 범위"),
+		@Parameter(name = "peerGender", description = "또래 성별")})
+	ResponseEntity<?> getPeerInfo(Long userId, int peerAgeStart, int peerAgeEnd, String peerGender);
+
+	@Operation(summary = "이번 달 소비 목표 수정 API", description = "다른 달의 소비 목표를 업데이트하는 것은 불가능하고 오직 이번 달의 소비 목표만 업데이트 하는 API 입니다.")
+	ResponseEntity<ConsumptionGoalResponseListDto> updateOrElseGenerateConsumptionGoal(Long userId,
+		ConsumptionGoalListRequestDto consumptionGoalListRequestDto);
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/controller/ConsumptionGoalController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/controller/ConsumptionGoalController.java
@@ -19,27 +19,15 @@ import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.PeerInfoResponseDTO;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.TopGoalCategoryResponseDTO;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.service.ConsumptionGoalService;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/consumption-goal")
-public class ConsumptionGoalController {
+public class ConsumptionGoalController implements ConsumptionGoalApi {
 
 	private final ConsumptionGoalService consumptionGoalService;
 
-	@Operation(summary = "또래들이 가장 큰 계획을 세운 카테고리 조회 API", description = "특정 사용자의 소비 목표 카테고리별 소비 목표 금액을 조회하는 API 입니다.")
-	@ApiResponses(value = {@ApiResponse(responseCode = "COMMON200", description = "OK, 성공")})
-	@Parameters({@Parameter(name = "top", description = "가장 큰 목표를 세운 카테고리의 개수를 지정합니다. (기본값은 5입니다)"),
-		@Parameter(name = "userId", description = "로그인 한 유저 아이디"),
-		@Parameter(name = "peerAgeStart", description = "또래나이 시작 범위"),
-		@Parameter(name = "peerAgeEnd", description = "또래나이 끝 범위"),
-		@Parameter(name = "peerGender", description = "또래 성별")})
 	@GetMapping("/top-categories")
 	public ResponseEntity<?> getTopGoalCategories(@RequestParam(name = "top", defaultValue = "5") int top,
 		@RequestParam(name = "userId") Long userId,
@@ -60,12 +48,6 @@ public class ConsumptionGoalController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "또래나이와 성별 조회 API", description = "또래나이와 성별을 조회하는 API 입니다.")
-	@ApiResponses(value = {@ApiResponse(responseCode = "COMMON200", description = "OK, 성공")})
-	@Parameters({@Parameter(name = "userId", description = "로그인 한 유저 아이디"),
-		@Parameter(name = "peerAgeStart", description = "또래나이 시작 범위"),
-		@Parameter(name = "peerAgeEnd", description = "또래나이 끝 범위"),
-		@Parameter(name = "peerGender", description = "또래 성별")})
 	@GetMapping("/peer-info")
 	public ResponseEntity<?> getPeerInfo(@RequestParam(name = "userId") Long userId,
 		@RequestParam(name = "peerAgeStart", defaultValue = "0") int peerAgeStart,

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/controller/ConsumptionGoalController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/controller/ConsumptionGoalController.java
@@ -7,10 +7,13 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalListRequestDto;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseListDto;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.PeerInfoResponseDTO;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.TopGoalCategoryResponseDTO;
@@ -32,8 +35,7 @@ public class ConsumptionGoalController {
 
 	@Operation(summary = "또래들이 가장 큰 계획을 세운 카테고리 조회 API", description = "특정 사용자의 소비 목표 카테고리별 소비 목표 금액을 조회하는 API 입니다.")
 	@ApiResponses(value = {@ApiResponse(responseCode = "COMMON200", description = "OK, 성공")})
-	@Parameters({
-		@Parameter(name = "top", description = "가장 큰 목표를 세운 카테고리의 개수를 지정합니다. (기본값은 5입니다)"),
+	@Parameters({@Parameter(name = "top", description = "가장 큰 목표를 세운 카테고리의 개수를 지정합니다. (기본값은 5입니다)"),
 		@Parameter(name = "userId", description = "로그인 한 유저 아이디"),
 		@Parameter(name = "peerAgeStart", description = "또래나이 시작 범위"),
 		@Parameter(name = "peerAgeEnd", description = "또래나이 끝 범위"),
@@ -60,8 +62,7 @@ public class ConsumptionGoalController {
 
 	@Operation(summary = "또래나이와 성별 조회 API", description = "또래나이와 성별을 조회하는 API 입니다.")
 	@ApiResponses(value = {@ApiResponse(responseCode = "COMMON200", description = "OK, 성공")})
-	@Parameters({
-		@Parameter(name = "userId", description = "로그인 한 유저 아이디"),
+	@Parameters({@Parameter(name = "userId", description = "로그인 한 유저 아이디"),
 		@Parameter(name = "peerAgeStart", description = "또래나이 시작 범위"),
 		@Parameter(name = "peerAgeEnd", description = "또래나이 끝 범위"),
 		@Parameter(name = "peerGender", description = "또래 성별")})
@@ -74,4 +75,11 @@ public class ConsumptionGoalController {
 		return ResponseEntity.ok(response);
 	}
 
+	@PostMapping("/{userId}")
+	public ResponseEntity<ConsumptionGoalResponseListDto> updateOrElseGenerateConsumptionGoal(@PathVariable Long userId,
+		@RequestBody ConsumptionGoalListRequestDto consumptionGoalListRequestDto) {
+
+		return ResponseEntity.ok()
+			.body(consumptionGoalService.updateConsumptionGoals(userId, consumptionGoalListRequestDto));
+	}
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/converter/ConsumptionGoalConverter.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/converter/ConsumptionGoalConverter.java
@@ -1,0 +1,28 @@
+package com.bbteam.budgetbuddies.domain.consumptiongoal.converter;
+
+import org.springframework.stereotype.Component;
+
+import com.bbteam.budgetbuddies.domain.category.entity.Category;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseDto;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.entity.ConsumptionGoal;
+
+@Component
+public class ConsumptionGoalConverter {
+	public ConsumptionGoalResponseDto toConsumptionGoalResponseDto(Category category) {
+		return ConsumptionGoalResponseDto.builder()
+			.categoryName(category.getName())
+			.categoryId(category.getId())
+			.goalAmount(0L)
+			.consumeAmount(0L)
+			.build();
+	}
+
+	public ConsumptionGoalResponseDto toConsumptionGoalResponseDto(ConsumptionGoal consumptionGoal) {
+		return ConsumptionGoalResponseDto.builder()
+			.categoryName(consumptionGoal.getCategory().getName())
+			.categoryId(consumptionGoal.getCategory().getId())
+			.goalAmount(consumptionGoal.getGoalAmount())
+			.consumeAmount(consumptionGoal.getConsumeAmount())
+			.build();
+	}
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalListRequestDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalListRequestDto.java
@@ -1,0 +1,15 @@
+package com.bbteam.budgetbuddies.domain.consumptiongoal.dto;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ConsumptionGoalListRequestDto {
+	List<ConsumptionGoalRequestDto> consumptionGoalList;
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalRequestDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalRequestDto.java
@@ -1,0 +1,14 @@
+package com.bbteam.budgetbuddies.domain.consumptiongoal.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ConsumptionGoalRequestDto {
+	private Long categoryId;
+	private Long goalAmount;
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalResponseDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalResponseDto.java
@@ -1,10 +1,5 @@
 package com.bbteam.budgetbuddies.domain.consumptiongoal.dto;
 
-import java.time.LocalDate;
-
-import com.bbteam.budgetbuddies.domain.category.entity.Category;
-import com.bbteam.budgetbuddies.domain.consumptiongoal.entity.ConsumptionGoal;
-
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,36 +9,12 @@ public class ConsumptionGoalResponseDto {
 	private Long categoryId;
 	private Long goalAmount;
 	private Long consumeAmount;
-	private LocalDate goalMonth;
 
 	@Builder
-	public ConsumptionGoalResponseDto(String categoryName, Long categoryId, Long goalAmount, Long consumeAmount,
-		LocalDate goalMonth) {
+	public ConsumptionGoalResponseDto(String categoryName, Long categoryId, Long goalAmount, Long consumeAmount) {
 		this.categoryName = categoryName;
 		this.categoryId = categoryId;
 		this.goalAmount = goalAmount;
 		this.consumeAmount = consumeAmount;
-		this.goalMonth = goalMonth;
-	}
-
-	public static ConsumptionGoalResponseDto initializeFromCategoryAndGoalMonth(Category category,
-		LocalDate goalMonth) {
-		return ConsumptionGoalResponseDto.builder()
-			.categoryName(category.getName())
-			.categoryId(category.getId())
-			.goalAmount(0L)
-			.consumeAmount(0L)
-			.goalMonth(goalMonth)
-			.build();
-	}
-
-	public static ConsumptionGoalResponseDto of(ConsumptionGoal consumptionGoal) {
-		return ConsumptionGoalResponseDto.builder()
-			.categoryName(consumptionGoal.getCategory().getName())
-			.categoryId(consumptionGoal.getCategory().getId())
-			.goalAmount(consumptionGoal.getGoalAmount())
-			.consumeAmount(consumptionGoal.getConsumeAmount())
-			.goalMonth(consumptionGoal.getGoalMonth())
-			.build();
 	}
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalResponseListDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalResponseListDto.java
@@ -1,5 +1,6 @@
 package com.bbteam.budgetbuddies.domain.consumptiongoal.dto;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import lombok.AccessLevel;
@@ -9,9 +10,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ConsumptionGoalResponseListDto {
+	private LocalDate goalMonth;
 	private List<ConsumptionGoalResponseDto> consumptionGoalList;
 
-	public ConsumptionGoalResponseListDto(List<ConsumptionGoalResponseDto> consumptionGoalResponseDtoList) {
-		this.consumptionGoalList = consumptionGoalResponseDtoList;
+	public ConsumptionGoalResponseListDto(LocalDate goalMonth, List<ConsumptionGoalResponseDto> consumptionGoalList) {
+		this.goalMonth = goalMonth;
+		this.consumptionGoalList = consumptionGoalList;
 	}
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/entity/ConsumptionGoal.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/entity/ConsumptionGoal.java
@@ -44,4 +44,7 @@ public class ConsumptionGoal extends BaseEntity {
 	@JoinColumn(name = "category_id")
 	private Category category;
 
+	public void updateGoalAmount(Long goalAmount) {
+		this.goalAmount = goalAmount;
+	}
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/entity/ConsumptionGoal.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/entity/ConsumptionGoal.java
@@ -26,11 +26,11 @@ import lombok.experimental.SuperBuilder;
 public class ConsumptionGoal extends BaseEntity {
 
 	@Column(nullable = false)
-	@Min(value = 1, message = "0 또는 음수의 목표금액을 설정할 수 없습니다.")
+	@Min(value = 0, message = "음수의 목표금액을 설정할 수 없습니다.")
 	private Long goalAmount;
 
 	@Column(nullable = false)
-	@Min(value = 1, message = "0 또는 음수의 소비금액을 설정할 수 없습니다.")
+	@Min(value = 0, message = "음수의 소비금액을 설정할 수 없습니다.")
 	private Long consumeAmount;
 
 	@Column(nullable = false)

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/repository/ConsumptionGoalRepository.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/repository/ConsumptionGoalRepository.java
@@ -2,13 +2,16 @@ package com.bbteam.budgetbuddies.domain.consumptiongoal.repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import com.bbteam.budgetbuddies.domain.category.entity.Category;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.entity.ConsumptionGoal;
+import com.bbteam.budgetbuddies.domain.user.entity.User;
 import com.bbteam.budgetbuddies.enums.Gender;
 
 @Repository
@@ -27,4 +30,7 @@ public interface ConsumptionGoalRepository extends JpaRepository<ConsumptionGoal
 
 	@Query(value = "SELECT cg FROM ConsumptionGoal AS cg WHERE cg.user.id = :userId AND cg.goalMonth = :goalMonth")
 	List<ConsumptionGoal> findConsumptionGoalByUserIdAndGoalMonth(Long userId, LocalDate goalMonth);
+
+	Optional<ConsumptionGoal> findConsumptionGoalByUserAndCategoryAndGoalMonth(User user, Category category,
+		LocalDate goalMonth);
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalService.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalListRequestDto;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseListDto;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.PeerInfoResponseDTO;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.TopGoalCategoryResponseDTO;
@@ -18,4 +19,7 @@ public interface ConsumptionGoalService {
 	ConsumptionGoalResponseListDto findUserConsumptionGoal(Long userId, LocalDate date);
 
 	PeerInfoResponseDTO getPeerInfo(Long userId, int peerAgeStart, int peerAgeEnd, String peerGender);
+
+	ConsumptionGoalResponseListDto updateConsumptionGoals(Long userId,
+		ConsumptionGoalListRequestDto consumptionGoalListRequestDto);
 }

--- a/src/test/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceTest.java
+++ b/src/test/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceTest.java
@@ -14,17 +14,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.bbteam.budgetbuddies.domain.category.entity.Category;
 import com.bbteam.budgetbuddies.domain.category.repository.CategoryRepository;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.converter.ConsumptionGoalConverter;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseDto;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.ConsumptionGoalResponseListDto;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.entity.ConsumptionGoal;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.repository.ConsumptionGoalRepository;
 import com.bbteam.budgetbuddies.domain.user.entity.User;
+import com.bbteam.budgetbuddies.domain.user.repository.UserRepository;
 
-@DisplayName("ConsumptionGoal 테스트의 ")
+@DisplayName("ConsumptionGoalImpl 서비스 테스트의 ")
 @ExtendWith(MockitoExtension.class)
 class ConsumptionGoalServiceTest {
 	private final LocalDate GOAL_MONTH = LocalDate.of(2024, 07, 01);
@@ -32,11 +35,15 @@ class ConsumptionGoalServiceTest {
 	private LocalDate goalMonth;
 
 	@InjectMocks
-	private ConsumptionGoalService consumptionGoalService;
+	private ConsumptionGoalServiceImpl consumptionGoalService;
+	@Mock
+	private ConsumptionGoalRepository consumptionGoalRepository;
 	@Mock
 	private CategoryRepository categoryRepository;
 	@Mock
-	private ConsumptionGoalRepository consumptionGoalRepository;
+	private UserRepository userRepository;
+	@Spy
+	private ConsumptionGoalConverter consumptionGoalConverter;
 
 	@BeforeEach
 	void setUp() {
@@ -63,7 +70,7 @@ class ConsumptionGoalServiceTest {
 		given(categoryRepository.findUserCategoryByUserId(user.getId())).willReturn(categoryList);
 
 		List<ConsumptionGoalResponseDto> expected = categoryList.stream()
-			.map(category -> ConsumptionGoalResponseDto.initializeFromCategoryAndGoalMonth(category, GOAL_MONTH))
+			.map(category -> consumptionGoalConverter.toConsumptionGoalResponseDto(category))
 			.toList();
 
 		// when
@@ -109,7 +116,7 @@ class ConsumptionGoalServiceTest {
 			GOAL_MONTH.minusMonths(1))).willReturn(previousGoalList);
 
 		List<ConsumptionGoalResponseDto> expected = previousGoalList.stream()
-			.map(ConsumptionGoalResponseDto::of)
+			.map(consumptionGoalConverter::toConsumptionGoalResponseDto)
 			.toList();
 
 		// when
@@ -153,6 +160,6 @@ class ConsumptionGoalServiceTest {
 
 		// then
 		assertThat(result.getConsumptionGoalList()).usingRecursiveComparison()
-			.isEqualTo(List.of(ConsumptionGoalResponseDto.of(goalMonthUserCategoryGoal)));
+			.isEqualTo(List.of(consumptionGoalConverter.toConsumptionGoalResponseDto(goalMonthUserCategoryGoal)));
 	}
 }


### PR DESCRIPTION
## 개요
> 소비 목표 수정하기
요구사항 중 이번 달의 소비목표만 수정할 수 있는 점을 고려하여, 이번 달만 수정 가능한 API로 구현

1. 목표 달 소비 목표 조회
    - 선행되어야 하는 과정, #13 에서 구현한 기능
2. 클라이언트는 전체 소비 목표 중 사용자가 업데이트 된 소비 목표만 서버에 전송
3. 서버에서는 소비 목표 엔티티가 있는지 조회(userId + categoryId + goalMonth)
    - 있으면 업데이트
    - 없으면 새로 생성


![스크린샷 2024-07-25 오후 2 14 08](https://github.com/user-attachments/assets/5bafa01e-def2-4681-85c5-41a2a4760ff8)
ConsumptionApi 인터페이스를 통해서 Swagger 문서 관련 코드와 로직 관련 코드를 분리

Converter 코드 구현 완료
테스트 코드 구현 완료
- 추후 리팩토링이 필요할 것 같음


## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.

## etc
추후 ConsumptionGoal 엔티티에 userId와 categoryId와 goalMonth에 대한 인덱싱을 추가