### PR TITLE
[feat] 소비 내역 추가 API

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/common/BaseEntity.java
+++ b/src/main/java/com/bbteam/budgetbuddies/common/BaseEntity.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Getter
 @SuperBuilder
 @SoftDelete // boolean 타입의 deleted 필드가 추가
 public abstract class BaseEntity {

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/ExpenseController.java
@@ -1,0 +1,37 @@
+package com.bbteam.budgetbuddies.domain.expense.controller;
+
+import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseRequestDto;
+import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
+import com.bbteam.budgetbuddies.domain.expense.service.ExpenseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/expenses")
+public class ExpenseController {
+
+    private final ExpenseService expenseService;
+
+    @Operation(summary = "소비 내역 추가", description = "사용자가 소비 내역을 추가합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @PostMapping("/add")
+    public ResponseEntity<ExpenseResponseDto> createExpense(
+            @Parameter(description = "user_id, category_id, amount, description, expenseDate")
+            @RequestBody ExpenseRequestDto expenseRequestDto) {
+        ExpenseResponseDto response = expenseService.createExpense(expenseRequestDto);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/package-info.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/package-info.java
@@ -1,1 +1,0 @@
-package com.bbteam.budgetbuddies.domain.expense.controller;

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/converter/ExpenseConverter.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/converter/ExpenseConverter.java
@@ -1,0 +1,34 @@
+package com.bbteam.budgetbuddies.domain.expense.converter;
+
+import com.bbteam.budgetbuddies.domain.category.entity.Category;
+import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseRequestDto;
+import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
+import com.bbteam.budgetbuddies.domain.expense.entity.Expense;
+import com.bbteam.budgetbuddies.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExpenseConverter {
+
+    public Expense toExpenseEntity(ExpenseRequestDto expenseRequestDto, User user, Category category) {
+        return Expense.builder()
+                .user(user)
+                .category(category)
+                .amount(expenseRequestDto.getAmount())
+                .description(expenseRequestDto.getDescription())
+                .expenseDate(expenseRequestDto.getExpenseDate())
+                .build();
+    }
+
+    public ExpenseResponseDto toExpenseResponseDto(Expense expense) {
+        return ExpenseResponseDto.builder()
+                .expenseId(expense.getId())
+                .userId(expense.getUser().getId())
+                .categoryId(expense.getCategory().getId())
+                .amount(expense.getAmount())
+                .description(expense.getDescription())
+                .expenseDate(expense.getExpenseDate())
+                .build();
+    }
+}
+

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/ExpenseRequestDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/ExpenseRequestDto.java
@@ -1,0 +1,20 @@
+package com.bbteam.budgetbuddies.domain.expense.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExpenseRequestDto {
+    private Long userId;
+    private Long categoryId;
+    private Long amount;
+    private String description;
+    private LocalDateTime expenseDate;
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/ExpenseResponseDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/ExpenseResponseDto.java
@@ -1,0 +1,21 @@
+package com.bbteam.budgetbuddies.domain.expense.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExpenseResponseDto {
+    private Long expenseId;
+    private Long userId;
+    private Long categoryId;
+    private Long amount;
+    private String description;
+    private LocalDateTime expenseDate;
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/package-info.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/package-info.java
@@ -1,1 +1,0 @@
-package com.bbteam.budgetbuddies.domain.expense.dto;

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/repository/ExpenseRepository.java
@@ -1,0 +1,16 @@
+package com.bbteam.budgetbuddies.domain.expense.repository;
+
+import com.bbteam.budgetbuddies.domain.expense.entity.Expense;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+    @Query("SELECT e FROM Expense e WHERE e.user.id = :userId AND e.category.id = :categoryId")
+    List<Expense> findByUserIdAndCategoryId(@Param("userId") Long userId, @Param("categoryId") Long categoryId);
+
+    @Query("SELECT e FROM Expense e WHERE e.user.id = :userId")
+    List<Expense> findByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/repository/ExpenseRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+
+    // 추후 적용 예정
     @Query("SELECT e FROM Expense e WHERE e.user.id = :userId AND e.category.id = :categoryId")
     List<Expense> findByUserIdAndCategoryId(@Param("userId") Long userId, @Param("categoryId") Long categoryId);
 

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/repository/package-info.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/repository/package-info.java
@@ -1,1 +1,0 @@
-package com.bbteam.budgetbuddies.domain.expense.repository;

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseService.java
@@ -1,0 +1,8 @@
+package com.bbteam.budgetbuddies.domain.expense.service;
+
+import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseRequestDto;
+import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
+
+public interface ExpenseService {
+    ExpenseResponseDto createExpense(ExpenseRequestDto expenseRequestDto);
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseService.java
@@ -2,6 +2,9 @@ package com.bbteam.budgetbuddies.domain.expense.service;
 
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseRequestDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
+import com.bbteam.budgetbuddies.domain.category.dto.CategoryResponseDTO;
+
+import java.util.List;
 
 public interface ExpenseService {
     ExpenseResponseDto createExpense(ExpenseRequestDto expenseRequestDto);

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseServiceImpl.java
@@ -1,0 +1,36 @@
+package com.bbteam.budgetbuddies.domain.expense.service;
+
+import com.bbteam.budgetbuddies.domain.category.entity.Category;
+import com.bbteam.budgetbuddies.domain.category.repository.CategoryRepository;
+import com.bbteam.budgetbuddies.domain.expense.converter.ExpenseConverter;
+import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseRequestDto;
+import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
+import com.bbteam.budgetbuddies.domain.expense.entity.Expense;
+import com.bbteam.budgetbuddies.domain.expense.repository.ExpenseRepository;
+import com.bbteam.budgetbuddies.domain.user.entity.User;
+import com.bbteam.budgetbuddies.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExpenseServiceImpl implements ExpenseService {
+
+    private final ExpenseRepository expenseRepository;
+    private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
+    private final ExpenseConverter expenseConverter;
+
+    @Override
+    public ExpenseResponseDto createExpense(ExpenseRequestDto expenseRequestDto) {
+        User user = userRepository.findById(expenseRequestDto.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("Invalid user ID"));
+        Category category = categoryRepository.findById(expenseRequestDto.getCategoryId())
+                .orElseThrow(() -> new IllegalArgumentException("Invalid category ID"));
+
+        Expense expense = expenseConverter.toExpenseEntity(expenseRequestDto, user, category);
+        expenseRepository.save(expense);
+
+        return expenseConverter.toExpenseResponseDto(expense);
+    }
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/package-info.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/package-info.java
@@ -1,1 +1,0 @@
-package com.bbteam.budgetbuddies.domain.expense.service;


### PR DESCRIPTION
## 개요
> 유저가 소비 내역을 추가하는 기능 구현

- 소비 목표의 ConsumptionAmount update 필요 (추후 fix 필요)
flow : 소비 내역을 추가하고 -> 해당 소비 내역에 대한 소비 목표가 존재할 경우(기존에 존재하는 소비 목표 or 새로 생성한 소비 목표) -> 이번 달 ConsumtionAmount 업데이트

## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
