### PR TITLE
[feat] 유저 별 카테고리 조회 API

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/domain/category/controller/CategoryApi.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/category/controller/CategoryApi.java
@@ -1,0 +1,40 @@
+package com.bbteam.budgetbuddies.domain.category.controller;
+
+import com.bbteam.budgetbuddies.domain.category.dto.CategoryRequestDTO;
+import com.bbteam.budgetbuddies.domain.category.dto.CategoryResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+public interface CategoryApi {
+
+    @Operation(summary = "카테고리 추가", description = "사용자가 직접 카테고리를 추가합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @PostMapping("/add")
+    ResponseEntity<CategoryResponseDTO> createCategory(
+            @Parameter(description = "user_id, name(사용자가 입력한 카테고리명), is_default(default 카테고리 여부)로 request")
+            @RequestBody CategoryRequestDTO categoryRequestDTO);
+
+
+    @Operation(summary = "유저 개인의 카테고리 조회", description = "유저의 카테고리(default + 개인 custom)를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(responseCode = "404", description = "Not Found")
+    })
+    @GetMapping("/get/{userId}")
+    ResponseEntity<List<CategoryResponseDTO>> getUserCategories(@PathVariable Long userId);
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/category/controller/CategoryController.java
@@ -3,12 +3,6 @@ package com.bbteam.budgetbuddies.domain.category.controller;
 import com.bbteam.budgetbuddies.domain.category.dto.CategoryRequestDTO;
 import com.bbteam.budgetbuddies.domain.category.dto.CategoryResponseDTO;
 import com.bbteam.budgetbuddies.domain.category.service.CategoryService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,34 +12,18 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/categories")
-public class CategoryController {
+public class CategoryController implements CategoryApi {
 
     private final CategoryService categoryService;
 
-    @Operation(summary = "카테고리 추가", description = "사용자가 직접 카테고리를 추가합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
-    })
+    @Override
     @PostMapping("/add")
-    public ResponseEntity<CategoryResponseDTO> createCategory(
-            @Parameter(description = "user_id, name(사용자가 입력한 카테고리명), is_default(default 카테고리 여부)로 request")
-            @RequestBody CategoryRequestDTO categoryRequestDTO
-    ) {
+    public ResponseEntity<CategoryResponseDTO> createCategory(@RequestBody CategoryRequestDTO categoryRequestDTO) {
         CategoryResponseDTO response = categoryService.createCategory(categoryRequestDTO);
         return ResponseEntity.ok(response);
     }
 
-
-    @Operation(summary = "유저 개인의 카테고리 조회", description = "유저의 카테고리(default + 개인 custom)를 조회합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "OK"),
-            @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Forbidden"),
-            @ApiResponse(responseCode = "404", description = "Not Found")
-    })
+    @Override
     @GetMapping("/get/{userId}")
     public ResponseEntity<List<CategoryResponseDTO>> getUserCategories(@PathVariable Long userId) {
         List<CategoryResponseDTO> response = categoryService.getUserCategories(userId);

--- a/src/main/java/com/bbteam/budgetbuddies/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/category/controller/CategoryController.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/categories")
@@ -33,6 +35,20 @@ public class CategoryController {
             @RequestBody CategoryRequestDTO categoryRequestDTO
     ) {
         CategoryResponseDTO response = categoryService.createCategory(categoryRequestDTO);
+        return ResponseEntity.ok(response);
+    }
+
+
+    @Operation(summary = "유저 개인의 카테고리 조회", description = "유저의 카테고리(default + 개인 custom)를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(responseCode = "404", description = "Not Found")
+    })
+    @GetMapping("/get/{userId}")
+    public ResponseEntity<List<CategoryResponseDTO>> getUserCategories(@PathVariable Long userId) {
+        List<CategoryResponseDTO> response = categoryService.getUserCategories(userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/category/service/CategoryService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/category/service/CategoryService.java
@@ -3,7 +3,10 @@ package com.bbteam.budgetbuddies.domain.category.service;
 import com.bbteam.budgetbuddies.domain.category.dto.CategoryRequestDTO;
 import com.bbteam.budgetbuddies.domain.category.dto.CategoryResponseDTO;
 
+import java.util.List;
+
 public interface CategoryService {
     CategoryResponseDTO createCategory(CategoryRequestDTO categoryRequestDTO);
+    List<CategoryResponseDTO> getUserCategories(Long userId);
 }
 

--- a/src/main/java/com/bbteam/budgetbuddies/domain/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/category/service/CategoryServiceImpl.java
@@ -47,11 +47,7 @@ public class CategoryServiceImpl implements CategoryService {
 
         List<Category> categories = categoryRepository.findUserCategoryByUserId(userId);
         return categories.stream()
-                .map(category -> CategoryResponseDTO.builder()
-                        .id(category.getId())
-                        .name(category.getName())
-                        .isDefault(category.getIsDefault())
-                        .build())
+                .map(categoryConverter::toCategoryResponseDTO)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/category/service/CategoryServiceImpl.java
@@ -11,6 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -34,5 +37,21 @@ public class CategoryServiceImpl implements CategoryService {
         Category savedCategory = categoryRepository.save(category);
 
         return categoryConverter.toCategoryResponseDTO(savedCategory);
+    }
+
+    @Override
+    public List<CategoryResponseDTO> getUserCategories(Long userId) {
+
+        userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
+
+        List<Category> categories = categoryRepository.findUserCategoryByUserId(userId);
+        return categories.stream()
+                .map(category -> CategoryResponseDTO.builder()
+                        .id(category.getId())
+                        .name(category.getName())
+                        .isDefault(category.getIsDefault())
+                        .build())
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 개요
> 기본으로 제공되는 default 카테고리(식비, 유흥, 카페, 경조사비, 간식, 패션 뷰티, 문화생활, 교통, 쇼핑, 정기결제) + 사용자가 직접 추가한 custom 카테고리 조회하는 기능

- 존재하지 않는 userId 조회 시 에러 발생
**- category 테이블에 default 카테고리 10개는 category_id 1~10에 해당(immutable).**
## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
