### PR TITLE
[test] 지원정보 API 테스트 코드 작성

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/entity/SupportInfo.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/entity/SupportInfo.java
@@ -3,10 +3,7 @@ package com.bbteam.budgetbuddies.domain.supportinfo.entity;
 import com.bbteam.budgetbuddies.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -26,10 +23,10 @@ public class SupportInfo extends BaseEntity {
 
     private LocalDate endDate;
 
-    @ColumnDefault("0")
+    @Builder.Default
     private Integer likeCount = 0;
 
-    @ColumnDefault("0")
+    @Builder.Default
     private Integer anonymousNumber = 0;
 
     @Column(length = 1000)

--- a/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/service/SupportInfoServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/service/SupportInfoServiceImpl.java
@@ -96,14 +96,22 @@ public class SupportInfoServiceImpl implements SupportInfoService {
         Optional<SupportInfoLike> existingLike = supportInfoLikeRepository.findByUserAndSupportInfo(user, supportInfo);
 
         if (existingLike.isPresent()) {
-            // 이미 좋아요를 누른 상태라면
-            supportInfoLikeRepository.delete(existingLike.get());
-            supportInfo.subLikeCount();
+            // 이미 객체가 존재한다면
+            if (existingLike.get().getIsLike()) {
+                // 좋아요를 누른 상태라면
+                existingLike.get().toggleLike();
+                supportInfo.subLikeCount();
+            } else {
+                // 좋아요를 누르지 않은 상태라면
+                existingLike.get().toggleLike();
+                supportInfo.addLikeCount();
+            }
         } else {
             // 아직 좋아요를 누르지 않은 상태라면
             SupportInfoLike newLike = SupportInfoLike.builder()
                 .user(user)
                 .supportInfo(supportInfo)
+                .isLike(true)
                 .build();
             supportInfoLikeRepository.save(newLike);
             supportInfo.addLikeCount();

--- a/src/main/java/com/bbteam/budgetbuddies/domain/supportinfolike/entity/SupportInfoLike.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/supportinfolike/entity/SupportInfoLike.java
@@ -7,10 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 @Entity
@@ -27,5 +24,12 @@ public class SupportInfoLike extends BaseEntity {
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "support_info_id")
     private SupportInfo supportInfo;
+
+    @Builder.Default
+    private Boolean isLike = false;
+
+    public void toggleLike() {
+        isLike = !isLike;
+    }
 
 }

--- a/src/test/java/com/bbteam/budgetbuddies/domain/supportinfo/repository/SupportInfoRepositoryTest.java
+++ b/src/test/java/com/bbteam/budgetbuddies/domain/supportinfo/repository/SupportInfoRepositoryTest.java
@@ -1,24 +1,78 @@
 package com.bbteam.budgetbuddies.domain.supportinfo.repository;
 
+import com.bbteam.budgetbuddies.domain.discountinfo.entity.DiscountInfo;
 import com.bbteam.budgetbuddies.domain.supportinfo.entity.SupportInfo;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
+@DataJpaTest
 @Transactional
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class SupportInfoRepositoryTest {
 
     @Autowired
     SupportInfoRepository supportInfoRepository;
 
+    @Test
+    @DisplayName("특정 년월에 속하는 지원 정보 데이터 조회 성공")
+    void findByDateRangeSuccess() {
+        // given
+        SupportInfo discount1 = SupportInfo.builder()
+            .title("지원정보1")
+            .startDate(LocalDate.of(2024, 7, 1))
+            .endDate(LocalDate.of(2024, 7, 21))
+            .siteUrl("http://example1.com")
+            .build();
+        supportInfoRepository.save(discount1);
+
+        // when
+        Page<SupportInfo> results = supportInfoRepository.findByDateRange(
+            LocalDate.of(2024, 7, 1),
+            LocalDate.of(2024, 7, 31),
+            PageRequest.of(0, 10)
+        );
+
+        // then
+        assertThat(results).hasSize(1);
+        assertThat(results.getContent().get(0).getTitle()).isEqualTo("지원정보1");
+    }
+
+    @Test
+    @DisplayName("특정 년월에 속하는 지원 정보 데이터 조회 실패")
+    void findByDateRangeFailure() {
+        // given
+        SupportInfo discount1 = SupportInfo.builder()
+            .title("지원정보1")
+            .startDate(LocalDate.of(2024, 6, 1))
+            .endDate(LocalDate.of(2024, 6, 21))
+            .siteUrl("http://example1.com")
+            .build();
+        supportInfoRepository.save(discount1);
+
+        // when
+        Page<SupportInfo> results = supportInfoRepository.findByDateRange(
+            LocalDate.of(2024, 7, 1),
+            LocalDate.of(2024, 7, 31),
+            PageRequest.of(0, 10)
+        );
+
+        // then
+        assertThat(results).hasSize(0);
+    }
 
     @Test
     void findByMonthTest(){

--- a/src/test/java/com/bbteam/budgetbuddies/domain/supportinfo/service/SupportInfoServiceTest.java
+++ b/src/test/java/com/bbteam/budgetbuddies/domain/supportinfo/service/SupportInfoServiceTest.java
@@ -1,0 +1,222 @@
+package com.bbteam.budgetbuddies.domain.supportinfo.service;
+
+import com.bbteam.budgetbuddies.domain.discountinfo.converter.DiscountInfoConverter;
+import com.bbteam.budgetbuddies.domain.discountinfo.dto.DiscountRequestDto;
+import com.bbteam.budgetbuddies.domain.discountinfo.dto.DiscountResponseDto;
+import com.bbteam.budgetbuddies.domain.discountinfo.entity.DiscountInfo;
+import com.bbteam.budgetbuddies.domain.discountinfo.repository.DiscountInfoRepository;
+import com.bbteam.budgetbuddies.domain.discountinfo.service.DiscountInfoServiceImpl;
+import com.bbteam.budgetbuddies.domain.discountinfolike.entity.DiscountInfoLike;
+import com.bbteam.budgetbuddies.domain.discountinfolike.repository.DiscountInfoLikeRepository;
+import com.bbteam.budgetbuddies.domain.supportinfo.converter.SupportInfoConverter;
+import com.bbteam.budgetbuddies.domain.supportinfo.dto.SupportRequestDto;
+import com.bbteam.budgetbuddies.domain.supportinfo.dto.SupportResponseDto;
+import com.bbteam.budgetbuddies.domain.supportinfo.entity.SupportInfo;
+import com.bbteam.budgetbuddies.domain.supportinfo.repository.SupportInfoRepository;
+import com.bbteam.budgetbuddies.domain.supportinfolike.entity.SupportInfoLike;
+import com.bbteam.budgetbuddies.domain.supportinfolike.repository.SupportInfoLikeRepository;
+import com.bbteam.budgetbuddies.domain.user.entity.User;
+import com.bbteam.budgetbuddies.domain.user.repository.UserRepository;
+import com.bbteam.budgetbuddies.enums.Gender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+class SupportInfoServiceTest {
+
+    @Mock
+    private SupportInfoRepository supportInfoRepository;
+
+    @Mock
+    private SupportInfoLikeRepository supportInfoLikeRepository;
+
+    @Mock
+    private SupportInfoConverter supportInfoConverter;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private SupportInfoServiceImpl supportInfoService;
+
+    @Test
+    @DisplayName("지원 정보 2개를 등록한 뒤, 호출했을 때 2개가 정상적으로 반환되는지 검증")
+    void getSupportsByYearAndMonthTest() {
+        // given
+        LocalDate startDate = LocalDate.of(2024, 7, 1);
+        LocalDate endDate = LocalDate.of(2024, 7, 31);
+        Pageable pageable = PageRequest.of(0, 10);
+
+        SupportInfo support1 = SupportInfo.builder()
+            .title("Support 1")
+            .startDate(startDate)
+            .endDate(endDate)
+            .siteUrl("http://example1.com")
+            .build();
+
+        SupportInfo support2 = SupportInfo.builder()
+            .title("Support 2")
+            .startDate(startDate)
+            .endDate(endDate)
+            .siteUrl("http://example2.com")
+            .build();
+
+        List<SupportInfo> supports = List.of(support1, support2);
+        Page<SupportInfo> supportPage = new PageImpl<>(supports, pageable, supports.size());
+
+        SupportResponseDto dto1 = new SupportResponseDto();
+        SupportResponseDto dto2 = new SupportResponseDto();
+
+        when(supportInfoRepository.findByDateRange(startDate, endDate, pageable)).thenReturn(supportPage);
+        when(supportInfoConverter.toDto(support1)).thenReturn(dto1);
+        when(supportInfoConverter.toDto(support2)).thenReturn(dto2);
+
+        // when
+        Page<SupportResponseDto> result = supportInfoService.getSupportsByYearAndMonth(2024, 7, 0, 10);
+
+        // then
+        // 1. 데이터가 2개인지 검증
+        // 2. 각 데이터 내용이 일치하는지 검증
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0)).isEqualTo(dto1);
+        assertThat(result.getContent().get(1)).isEqualTo(dto2);
+
+        // 3. 각 메소드가 1번씩만 호출되었는지 검증
+        verify(supportInfoRepository, times(1)).findByDateRange(startDate, endDate, pageable);
+        verify(supportInfoConverter, times(1)).toDto(support1);
+        verify(supportInfoConverter, times(1)).toDto(support2);
+    }
+
+    @Test
+    @DisplayName("지원 정보 등록이 정상적으로 되는지 검증")
+    void registerSupportInfoTest() {
+        // given
+        SupportRequestDto requestDto = SupportRequestDto.builder()
+            .title("지원 정보 제목")
+            .startDate(LocalDate.of(2024, 7, 1))
+            .endDate(LocalDate.of(2024, 7, 21))
+            .siteUrl("http://example.com")
+            .build();
+
+        SupportInfo entity = SupportInfo.builder()
+            .title("지원 정보 제목")
+            .startDate(LocalDate.of(2024, 7, 1))
+            .endDate(LocalDate.of(2024, 7, 21))
+            .siteUrl("http://example.com")
+            .build();
+
+        SupportResponseDto responseDto = SupportResponseDto.builder()
+            .id(1L)
+            .title("지원 정보 제목")
+            .startDate(LocalDate.of(2024, 7, 1))
+            .endDate(LocalDate.of(2024, 7, 21))
+            .siteUrl("http://example.com")
+            .likeCount(0)
+            .anonymousNumber(0)
+            .build();
+
+        when(supportInfoConverter.toEntity(requestDto)).thenReturn(entity);
+        when(supportInfoRepository.save(entity)).thenReturn(entity);
+        when(supportInfoConverter.toDto(entity)).thenReturn(responseDto);
+
+        // when
+        SupportResponseDto result = supportInfoService.registerSupportInfo(requestDto);
+
+        // then
+        // 1. 데이터 내용이 일치하는지 검증
+        assertThat(result).isEqualTo(responseDto);
+
+        // 2. 각 메소드가 1번씩만 호출되었는지 검증
+        verify(supportInfoConverter, times(1)).toEntity(requestDto);
+        verify(supportInfoRepository, times(1)).save(entity);
+        verify(supportInfoConverter, times(1)).toDto(entity);
+    }
+
+    @Test
+    @DisplayName("좋아요를 처음 눌렀을 때 1을 반환하는지 검증")
+    void toggleLikeTest() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .phoneNumber("010-1234-5678")
+            .name("John")
+            .age(30)
+            .gender(Gender.MALE)
+            .email("john.doe@example.com")
+            .photoUrl("http://example.com/photo.jpg")
+            .consumptionPattern("Regular")
+            .lastLoginAt(LocalDateTime.now())
+            .build();
+
+        SupportInfo supportInfo = SupportInfo.builder()
+            .id(1L)
+            .title("지원 정보 제목")
+            .startDate(LocalDate.of(2024, 7, 20))
+            .endDate(LocalDate.of(2024, 7, 30))
+            .likeCount(0)
+            .anonymousNumber(0)
+            .siteUrl("http://example.com")
+            .build();
+
+        SupportInfoLike supportInfoLike = SupportInfoLike.builder()
+            .id(1L)
+            .user(user)
+            .supportInfo(supportInfo)
+            .isLike(false)
+            .build();
+
+        SupportResponseDto responseDto = SupportResponseDto.builder()
+            .id(1L)
+            .title("지원 정보 제목")
+            .startDate(LocalDate.of(2024, 7, 20))
+            .endDate(LocalDate.of(2024, 7, 30))
+            .likeCount(1)
+            .anonymousNumber(0)
+            .siteUrl("http://example.com")
+            .build();
+
+        when(supportInfoRepository.save(any(SupportInfo.class))).thenReturn(supportInfo);
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        when(supportInfoRepository.findById(anyLong())).thenReturn(Optional.of(supportInfo));
+        when(supportInfoLikeRepository.findByUserAndSupportInfo(user, supportInfo)).thenReturn(Optional.of(supportInfoLike));
+        when(supportInfoConverter.toDto(any(SupportInfo.class))).thenReturn(responseDto);
+
+        // when
+        SupportResponseDto result = supportInfoService.toggleLike(1L, 1L);
+
+        // then
+        // 1. 결과 객체 비교 검증
+        assertThat(result).isEqualTo(responseDto);
+
+        // 2. 좋아요 개수 0 -> 1로 증가했는지 검증
+        assertThat(supportInfo.getLikeCount()).isEqualTo(1);
+
+        // 3. 각 메소드가 1번씩만 호출되었는지 검증
+        verify(supportInfoRepository, times(1)).findById(1L);
+        verify(supportInfoRepository, times(1)).save(supportInfo);
+        verify(supportInfoConverter, times(1)).toDto(supportInfo);
+    }
+
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#42 
- SupportInfoLike 엔티티에 isLike 필드를 추가하여 토글이 간편하도록 수정
- isLike 필드를 사용하도록 SupportInfoService 로직 수정
- SupportInfoRepository 테스트 코드 작성
   1) 특정 년월에 속하는 지원 정보 데이터 조회 성공
   2) 특정 년월에 속하는 지원 정보 데이터 조회 실패
- SupportInfoService 테스트 코드 작성
   1) 지원 정보 2개를 등록한 뒤, 호출했을 때 2개가 정상적으로 반환되는지 검증
   2) 지원 정보 등록이 정상적으로 되는지 검증
   3) 좋아요를 처음 눌렀을 때 1을 반환하는지 검증

## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
