### PR TITLE
[feat] 소비 추가 -> 소비 목표 추가 로직 구현

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/category/repository/CategoryRepository.java
@@ -12,5 +12,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 	@Query(value = "SELECT c FROM Category AS c WHERE c.isDefault=TRUE OR c.user.id=:id")
 	List<Category> findUserCategoryByUserId(@Param("id") Long id);
 
+	@Query("SELECT c FROM Category c WHERE c.isDefault = true")
+	List<Category> findAllByIsDefaultTrue();
 	boolean existsByUserIdAndName(Long userId, String name);
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/converter/ConsumptionGoalConverter.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/converter/ConsumptionGoalConverter.java
@@ -3,6 +3,7 @@ package com.bbteam.budgetbuddies.domain.consumptiongoal.converter;
 import java.time.LocalDate;
 import java.util.List;
 
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.UserConsumptionGoalResponse;
 import org.springframework.stereotype.Component;
 
 import com.bbteam.budgetbuddies.domain.category.entity.Category;
@@ -47,5 +48,14 @@ public class ConsumptionGoalConverter {
 
 	private Long sumTotalGoalAmount(List<ConsumptionGoalResponseDto> consumptionGoalList) {
 		return consumptionGoalList.stream().reduce(0L, (sum, c2) -> sum + c2.getGoalAmount(), Long::sum);
+	}
+
+	public UserConsumptionGoalResponse toUserConsumptionGoalResponse(ConsumptionGoal consumptionGoal) {
+		return UserConsumptionGoalResponse.builder()
+				.categoryId(consumptionGoal.getCategory().getId())
+				.goalMonth(consumptionGoal.getGoalMonth())
+				.consumeAmount(consumptionGoal.getConsumeAmount())
+				.goalAmount(consumptionGoal.getGoalAmount())
+				.build();
 	}
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/UserConsumptionGoalResponse.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/UserConsumptionGoalResponse.java
@@ -1,0 +1,15 @@
+package com.bbteam.budgetbuddies.domain.consumptiongoal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class UserConsumptionGoalResponse {
+    private Long categoryId;
+    private LocalDate goalMonth;
+    private Long consumeAmount;
+    private Long goalAmount;
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/user/controller/UserController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/user/controller/UserController.java
@@ -1,0 +1,23 @@
+package com.bbteam.budgetbuddies.domain.user.controller;
+
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.UserConsumptionGoalResponse;
+import com.bbteam.budgetbuddies.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+        import java.util.List;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/{userId}/add/default-categories/consumption-goal")
+    public ResponseEntity<List<UserConsumptionGoalResponse>> createConsumptionGoals(@PathVariable Long userId) {
+        List<UserConsumptionGoalResponse> consumptionGoals = userService.createConsumptionGoalWithDefaultGoals(userId);
+        return ResponseEntity.ok(consumptionGoals);
+    }
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/user/controller/package-info.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/user/controller/package-info.java
@@ -1,1 +1,0 @@
-package com.bbteam.budgetbuddies.domain.user.controller;

--- a/src/main/java/com/bbteam/budgetbuddies/domain/user/service/UserService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/user/service/UserService.java
@@ -1,0 +1,8 @@
+package com.bbteam.budgetbuddies.domain.user.service;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.UserConsumptionGoalResponse;
+
+import java.util.List;
+
+public interface UserService {
+    List<UserConsumptionGoalResponse> createConsumptionGoalWithDefaultGoals(Long userId);
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,51 @@
+package com.bbteam.budgetbuddies.domain.user.service;
+
+import com.bbteam.budgetbuddies.domain.category.entity.Category;
+import com.bbteam.budgetbuddies.domain.category.repository.CategoryRepository;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.converter.ConsumptionGoalConverter;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.UserConsumptionGoalResponse;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.entity.ConsumptionGoal;
+import com.bbteam.budgetbuddies.domain.consumptiongoal.repository.ConsumptionGoalRepository;
+import com.bbteam.budgetbuddies.domain.user.entity.User;
+import com.bbteam.budgetbuddies.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
+    private final ConsumptionGoalRepository consumptionGoalRepository;
+    private final ConsumptionGoalConverter consumptionGoalConverter;
+
+    @Override
+    @Transactional
+    public List<UserConsumptionGoalResponse> createConsumptionGoalWithDefaultGoals(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        List<Category> defaultCategories = categoryRepository.findAllByIsDefaultTrue();
+        List<ConsumptionGoal> consumptionGoals = defaultCategories.stream()
+                .map(category -> ConsumptionGoal.builder()
+                        .user(user)
+                        .category(category)
+                        .goalMonth(LocalDate.now().withDayOfMonth(1))
+                        .consumeAmount(0L)
+                        .goalAmount(0L)
+                        .build())
+                .collect(Collectors.toList());
+
+        List<ConsumptionGoal> savedConsumptionGoals = consumptionGoalRepository.saveAll(consumptionGoals);
+
+        return savedConsumptionGoals.stream()
+                .map(consumptionGoalConverter::toUserConsumptionGoalResponse)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/user/service/package-info.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/user/service/package-info.java
@@ -1,1 +1,0 @@
-package com.bbteam.budgetbuddies.domain.user.service;


### PR DESCRIPTION
## 개요
1) default category(10개) : DB에 1~10번 필드에 is_default = True로 존재 (불변) -> 유저가 계정 생성과 동시에 이 10개는 가지게 됨
2) custom cateogory : 사용자가 추가하면 생성
3) default category의 경우 해당 유저 계정이 생성되면 그에 대한 ConsumptionGoal의 ConsumeAmount는 0 (계정이 생성되면 이 10개에 대한 ConsumptionGoal은 바로 생성이 되게끔)
4) 유저가 custom 카테고리 생성 -> 해당 카테고리에 대한 ConsumptionGoal 바로 생성 -> ConsumeAmount는 0
ex) 한 열흘 지나서 유저가 이 카테고리에 대한 소비 목표 금액을 설정하면 -> 그 소비 목표 금액으로 ConsumeAmount가 업데이트. 그리고 이 소비 목표 금액은 이 유저가 소비 목표를 삭제하거나 변경할 때까지 다음 달로 계에속 이월
## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
