### PR TITLE
[feat] 유저가 가계부에 작성한 소비 내역을 삭제하는 API

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/entity/ConsumptionGoal.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/entity/ConsumptionGoal.java
@@ -17,12 +17,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @SuperBuilder
+@Slf4j
 public class ConsumptionGoal extends BaseEntity {
 
 	@Column(nullable = false)
@@ -54,5 +56,12 @@ public class ConsumptionGoal extends BaseEntity {
 
 	public void restoreConsumeAmount(Long previousAmount) {
 		this.consumeAmount -= previousAmount;
+	}
+
+	public void decreaseConsumeAmount(Long amount) {
+		if (this.consumeAmount - amount < 0) {
+			log.warn("소비 내역 삭제의 결과가 음수이므로 확인이 필요합니다.(현재 소비 금액: {}, 차감할 금액: {}). 소비 금액을 0으로 설정합니다.", this.consumeAmount, amount);
+		}
+		this.consumeAmount = Math.max(0, this.consumeAmount - amount);
 	}
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalService.java
@@ -21,17 +21,17 @@ import com.bbteam.budgetbuddies.domain.user.entity.User;
 public interface ConsumptionGoalService {
 
 	List<TopGoalCategoryResponseDTO> getTopGoalCategoriesLimit(int top, Long userId, int peerAgeStart, int peerAgeEnd,
-		String peerGender);
+															   String peerGender);
 
 	Page<TopGoalCategoryResponseDTO> getTopGoalCategories(Long userId, int peerAgeStart, int peerAgeEnd,
-		String peerGender, Pageable pageable);
+														  String peerGender, Pageable pageable);
 
 	ConsumptionGoalResponseListDto findUserConsumptionGoalList(Long userId, LocalDate date);
 
 	PeerInfoResponseDTO getPeerInfo(Long userId, int peerAgeStart, int peerAgeEnd, String peerGender);
 
 	ConsumptionGoalResponseListDto updateConsumptionGoals(Long userId,
-		ConsumptionGoalListRequestDto consumptionGoalListRequestDto);
+														  ConsumptionGoalListRequestDto consumptionGoalListRequestDto);
 
 	ConsumptionAnalysisResponseDTO getTopCategoryAndConsumptionAmount(Long userId);
 
@@ -39,9 +39,10 @@ public interface ConsumptionGoalService {
 
 	void updateConsumeAmount(Long userId, Long categoryId, Long amount);
 
-	List<TopConsumptionResponseDTO> getTopConsumptionsLimit(int top, Long userId, int peerAgeS, int peerAgeE,
-		String peerG);
+	void decreaseConsumeAmount(Long userId, Long categoryId, Long amount, LocalDate expenseDate);
+
+	List<TopConsumptionResponseDTO> getTopConsumption(int top, Long userId, int peerAgeS, int peerAgeE, String peerG);
 
 	Page<TopConsumptionResponseDTO> getTopConsumptions(Long userId, int peerAgeS, int peerAgeE,
-		String peerG, Pageable pageable);
+													   String peerG, Pageable pageable);
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceImpl.java
@@ -63,24 +63,24 @@ public class ConsumptionGoalServiceImpl implements ConsumptionGoalService {
 	@Override
 	@Transactional(readOnly = true)
 	public List<TopGoalCategoryResponseDTO> getTopGoalCategoriesLimit(int top, Long userId, int peerAgeS, int peerAgeE,
-		String peerG) {
+																	  String peerG) {
 
 		checkPeerInfo(userId, peerAgeS, peerAgeE, peerG);
 
 		List<ConsumptionGoal> topGoals = consumptionGoalRepository.findTopCategoriesAndGoalAmountLimit(top,
-			peerAgeStart, peerAgeEnd, peerGender, currentMonth);
+				peerAgeStart, peerAgeEnd, peerGender, currentMonth);
 		return topGoals.stream().map(TopCategoryConverter::fromEntity).collect(Collectors.toList());
 	}
 
 	@Override
 	@Transactional(readOnly = true)
 	public Page<TopGoalCategoryResponseDTO> getTopGoalCategories(Long userId, int peerAgeS, int peerAgeE, String peerG,
-		Pageable pageable) {
+																 Pageable pageable) {
 
 		checkPeerInfo(userId, peerAgeS, peerAgeE, peerG);
 
 		Page<ConsumptionGoal> topGoals = consumptionGoalRepository.findTopCategoriesAndGoalAmount(peerAgeStart,
-			peerAgeEnd, peerGender, currentMonth, pageable);
+				peerAgeEnd, peerGender, currentMonth, pageable);
 		return topGoals.map(TopCategoryConverter::fromEntity);
 	}
 
@@ -100,12 +100,12 @@ public class ConsumptionGoalServiceImpl implements ConsumptionGoalService {
 		checkPeerInfo(userId, 0, 0, "none");
 
 		ConsumptionGoal topConsumptionGoal = consumptionGoalRepository.findTopCategoriesAndGoalAmountLimit(1,
-			peerAgeStart, peerAgeEnd, peerGender, currentMonth).get(0);
+				peerAgeStart, peerAgeEnd, peerGender, currentMonth).get(0);
 
 		ConsumptionGoal currentWeekConsumptionAmount = consumptionGoalRepository.findTopConsumptionByCategoryIdAndCurrentWeek(
-				topConsumptionGoal.getCategory().getId(), startOfWeek, endOfWeek)
-			.orElseThrow(() -> new IllegalArgumentException(
-				"카테고리 ID " + topConsumptionGoal.getCategory().getId() + "에 대한 현재 주 소비 데이터가 없습니다."));
+						topConsumptionGoal.getCategory().getId(), startOfWeek, endOfWeek)
+				.orElseThrow(() -> new IllegalArgumentException(
+						"카테고리 ID " + topConsumptionGoal.getCategory().getId() + "에 대한 현재 주 소비 데이터가 없습니다."));
 
 		Long totalConsumptionAmountForCurrentWeek = currentWeekConsumptionAmount.getConsumeAmount();
 
@@ -114,23 +114,23 @@ public class ConsumptionGoalServiceImpl implements ConsumptionGoalService {
 
 	@Override
 	public List<TopConsumptionResponseDTO> getTopConsumptionsLimit(int top, Long userId, int peerAgeS, int peerAgeE,
-		String peerG) {
+																   String peerG) {
 
 		checkPeerInfo(userId, peerAgeS, peerAgeE, peerG);
 
 		List<ConsumptionGoal> topConsumptions = consumptionGoalRepository.findTopConsumptionAndConsumeAmountLimit(top,
-			peerAgeStart, peerAgeEnd, peerGender, currentMonth);
+				peerAgeStart, peerAgeEnd, peerGender, currentMonth);
 		return topConsumptions.stream().map(TopConsumptionConverter::fromEntity).collect(Collectors.toList());
 	}
 
 	@Override
 	public Page<TopConsumptionResponseDTO> getTopConsumptions(Long userId, int peerAgeS, int peerAgeE, String peerG,
-		Pageable pageable) {
+															  Pageable pageable) {
 
 		checkPeerInfo(userId, peerAgeS, peerAgeE, peerG);
 
 		Page<ConsumptionGoal> topConsumptions = consumptionGoalRepository.findTopConsumptionAndConsumeAmount(
-			peerAgeStart, peerAgeEnd, peerGender, currentMonth, pageable);
+				peerAgeStart, peerAgeEnd, peerGender, currentMonth, pageable);
 		return topConsumptions.map(TopConsumptionConverter::fromEntity);
 	}
 
@@ -182,28 +182,28 @@ public class ConsumptionGoalServiceImpl implements ConsumptionGoalService {
 	@Override
 	@Transactional
 	public ConsumptionGoalResponseListDto updateConsumptionGoals(Long userId,
-		ConsumptionGoalListRequestDto consumptionGoalListRequestDto) {
+																 ConsumptionGoalListRequestDto consumptionGoalListRequestDto) {
 		LocalDate thisMonth = LocalDate.now().withDayOfMonth(1);
 		User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("Not found user"));
 
 		List<ConsumptionGoal> updatedConsumptionGoal = consumptionGoalListRequestDto.getConsumptionGoalList()
-			.stream()
-			.map(c -> updateConsumptionGoalWithRequestDto(user, c, thisMonth))
-			.toList();
+				.stream()
+				.map(c -> updateConsumptionGoalWithRequestDto(user, c, thisMonth))
+				.toList();
 
 		List<ConsumptionGoalResponseDto> response = consumptionGoalRepository.saveAll(updatedConsumptionGoal)
-			.stream()
-			.map(consumptionGoalConverter::toConsumptionGoalResponseDto)
-			.toList();
+				.stream()
+				.map(consumptionGoalConverter::toConsumptionGoalResponseDto)
+				.toList();
 
 		return consumptionGoalConverter.toConsumptionGoalResponseListDto(response, thisMonth);
 	}
 
 	private ConsumptionGoal updateConsumptionGoalWithRequestDto(User user,
-		ConsumptionGoalRequestDto consumptionGoalRequestDto, LocalDate goalMonth) {
+																ConsumptionGoalRequestDto consumptionGoalRequestDto, LocalDate goalMonth) {
 
 		Category category = categoryRepository.findById(consumptionGoalRequestDto.getCategoryId())
-			.orElseThrow(() -> new IllegalArgumentException("Not found Category"));
+				.orElseThrow(() -> new IllegalArgumentException("Not found Category"));
 
 		ConsumptionGoal consumptionGoal = findOrElseGenerateConsumptionGoal(user, category, goalMonth);
 		consumptionGoal.updateGoalAmount(consumptionGoalRequestDto.getGoalAmount());
@@ -213,17 +213,17 @@ public class ConsumptionGoalServiceImpl implements ConsumptionGoalService {
 
 	private ConsumptionGoal findOrElseGenerateConsumptionGoal(User user, Category category, LocalDate goalMonth) {
 		return consumptionGoalRepository.findConsumptionGoalByUserAndCategoryAndGoalMonth(user, category, goalMonth)
-			.orElseGet(() -> generateNewConsumptionGoal(user, category, goalMonth));
+				.orElseGet(() -> generateNewConsumptionGoal(user, category, goalMonth));
 	}
 
 	private ConsumptionGoal generateNewConsumptionGoal(User user, Category category, LocalDate goalMonth) {
 		return ConsumptionGoal.builder()
-			.goalMonth(goalMonth)
-			.user(user)
-			.category(category)
-			.consumeAmount(0L)
-			.goalAmount(0L)
-			.build();
+				.goalMonth(goalMonth)
+				.user(user)
+				.category(category)
+				.consumeAmount(0L)
+				.goalAmount(0L)
+				.build();
 	}
 
 	@Override
@@ -240,25 +240,25 @@ public class ConsumptionGoalServiceImpl implements ConsumptionGoalService {
 
 	private Map<Long, ConsumptionGoalResponseDto> initializeGoalMap(Long userId) {
 		return categoryRepository.findUserCategoryByUserId(userId)
-			.stream()
-			.collect(Collectors.toMap(Category::getId, consumptionGoalConverter::toConsumptionGoalResponseDto));
+				.stream()
+				.collect(Collectors.toMap(Category::getId, consumptionGoalConverter::toConsumptionGoalResponseDto));
 	}
 
 	private void updateGoalMapWithPreviousMonth(Long userId, LocalDate goalMonth,
-		Map<Long, ConsumptionGoalResponseDto> goalMap) {
+												Map<Long, ConsumptionGoalResponseDto> goalMap) {
 		updateGoalMap(userId, goalMonth.minusMonths(1), goalMap);
 	}
 
 	private void updateGoalMapWithCurrentMonth(Long userId, LocalDate goalMonth,
-		Map<Long, ConsumptionGoalResponseDto> goalMap) {
+											   Map<Long, ConsumptionGoalResponseDto> goalMap) {
 		updateGoalMap(userId, goalMonth, goalMap);
 	}
 
 	private void updateGoalMap(Long userId, LocalDate month, Map<Long, ConsumptionGoalResponseDto> goalMap) {
 		consumptionGoalRepository.findConsumptionGoalByUserIdAndGoalMonth(userId, month)
-			.stream()
-			.map(consumptionGoalConverter::toConsumptionGoalResponseDto)
-			.forEach(goal -> goalMap.put(goal.getCategoryId(), goal));
+				.stream()
+				.map(consumptionGoalConverter::toConsumptionGoalResponseDto)
+				.forEach(goal -> goalMap.put(goal.getCategoryId(), goal));
 	}
 
 	@Override
@@ -270,8 +270,8 @@ public class ConsumptionGoalServiceImpl implements ConsumptionGoalService {
 
 	private void restorePreviousGoalConsumptionAmount(Expense expense, User user) {
 		ConsumptionGoal previousConsumptionGoal = consumptionGoalRepository.findConsumptionGoalByUserAndCategoryAndGoalMonth(
-				user, expense.getCategory(), expense.getExpenseDate().toLocalDate().withDayOfMonth(1))
-			.orElseThrow(() -> new IllegalArgumentException("Not found consumptionGoal"));
+						user, expense.getCategory(), expense.getExpenseDate().toLocalDate().withDayOfMonth(1))
+				.orElseThrow(() -> new IllegalArgumentException("Not found consumptionGoal"));
 
 		previousConsumptionGoal.restoreConsumeAmount(expense.getAmount());
 		consumptionGoalRepository.save(previousConsumptionGoal);
@@ -279,12 +279,12 @@ public class ConsumptionGoalServiceImpl implements ConsumptionGoalService {
 
 	private void calculatePresentGoalConsumptionAmount(ExpenseUpdateRequestDto request, User user) {
 		Category categoryToReplace = categoryRepository.findById(request.getCategoryId())
-			.orElseThrow(() -> new IllegalArgumentException("Not found category"));
+				.orElseThrow(() -> new IllegalArgumentException("Not found category"));
 
 		ConsumptionGoal consumptionGoal = consumptionGoalRepository.findConsumptionGoalByUserAndCategoryAndGoalMonth(
-				user, categoryToReplace, request.getExpenseDate().toLocalDate().withDayOfMonth(1))
-			.orElseGet(() -> this.generateGoalByPreviousOrElseNew(user, categoryToReplace,
-				request.getExpenseDate().toLocalDate().withDayOfMonth(1)));
+						user, categoryToReplace, request.getExpenseDate().toLocalDate().withDayOfMonth(1))
+				.orElseGet(() -> this.generateGoalByPreviousOrElseNew(user, categoryToReplace,
+						request.getExpenseDate().toLocalDate().withDayOfMonth(1)));
 
 		consumptionGoal.updateConsumeAmount(request.getAmount());
 		consumptionGoalRepository.save(consumptionGoal);
@@ -294,18 +294,18 @@ public class ConsumptionGoalServiceImpl implements ConsumptionGoalService {
 		LocalDate previousMonth = goalMonth.minusMonths(1);
 
 		return consumptionGoalRepository.findConsumptionGoalByUserAndCategoryAndGoalMonth(user, category, previousMonth)
-			.map(this::generateGoalByPrevious)
-			.orElseGet(() -> generateNewConsumptionGoal(user, category, goalMonth));
+				.map(this::generateGoalByPrevious)
+				.orElseGet(() -> generateNewConsumptionGoal(user, category, goalMonth));
 	}
 
 	private ConsumptionGoal generateGoalByPrevious(ConsumptionGoal consumptionGoal) {
 		return ConsumptionGoal.builder()
-			.goalMonth(consumptionGoal.getGoalMonth().plusMonths(1))
-			.user(consumptionGoal.getUser())
-			.category(consumptionGoal.getCategory())
-			.consumeAmount(0L)
-			.goalAmount(consumptionGoal.getGoalAmount())
-			.build();
+				.goalMonth(consumptionGoal.getGoalMonth().plusMonths(1))
+				.user(consumptionGoal.getUser())
+				.category(consumptionGoal.getCategory())
+				.consumeAmount(0L)
+				.goalAmount(consumptionGoal.getGoalAmount())
+				.build();
 	}
 
 	@Override
@@ -313,13 +313,41 @@ public class ConsumptionGoalServiceImpl implements ConsumptionGoalService {
 		User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("Not found user"));
 
 		Category category = categoryRepository.findById(categoryId)
-			.orElseThrow(() -> new IllegalArgumentException("Not found Category"));
+				.orElseThrow(() -> new IllegalArgumentException("Not found Category"));
 
 		LocalDate thisMonth = LocalDate.now().withDayOfMonth(1);
 		ConsumptionGoal consumptionGoal = consumptionGoalRepository.findConsumptionGoalByUserAndCategoryAndGoalMonth(
-			user, category, thisMonth).orElseGet(() -> generateNewConsumptionGoal(user, category, thisMonth));
+				user, category, thisMonth).orElseGet(() -> generateNewConsumptionGoal(user, category, thisMonth));
 
 		consumptionGoal.updateConsumeAmount(amount);
+		consumptionGoalRepository.save(consumptionGoal);
+	}
+
+	@Override
+	public List<TopConsumptionResponseDTO> getTopConsumption(int top, Long userId, int peerAgeS, int peerAgeE,
+															 String peerG) {
+
+		checkPeerInfo(userId, peerAgeS, peerAgeE, peerG);
+
+		List<ConsumptionGoal> topConsumptions = consumptionGoalRepository.findTopConsumptionAndConsumeAmount(top,
+				peerAgeStart, peerAgeEnd, peerGender);
+		return topConsumptions.stream().map(TopConsumptionConverter::fromEntity).collect(Collectors.toList());
+	}
+
+	@Override
+	public void decreaseConsumeAmount(Long userId, Long categoryId, Long amount, LocalDate expenseDate) {
+		User user = userRepository.findById(userId)
+				.orElseThrow(() -> new IllegalArgumentException("Not found user"));
+
+		Category category = categoryRepository.findById(categoryId)
+				.orElseThrow(() -> new IllegalArgumentException("Not found Category"));
+
+		LocalDate goalMonth = expenseDate.withDayOfMonth(1);
+		ConsumptionGoal consumptionGoal = consumptionGoalRepository
+				.findConsumptionGoalByUserAndCategoryAndGoalMonth(user, category, goalMonth)
+				.orElseThrow(() -> new IllegalArgumentException("Not found ConsumptionGoal"));
+
+		consumptionGoal.decreaseConsumeAmount(amount);
 		consumptionGoalRepository.save(consumptionGoal);
 	}
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/ExpenseApi.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/ExpenseApi.java
@@ -19,38 +19,45 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.DeleteMapping;
 
 public interface ExpenseApi {
 	@Operation(summary = "소비 내역 추가", description = "사용자가 소비 내역을 추가합니다.")
 	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-		@ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-		@ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+			@ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+			@ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
 	ResponseEntity<ExpenseResponseDto> createExpense(
-		@Parameter(description = "user_id, category_id, amount, description, expenseDate") ExpenseRequestDto expenseRequestDto);
+			@Parameter(description = "user_id, category_id, amount, description, expenseDate") ExpenseRequestDto expenseRequestDto);
 
 	@Operation(summary = "월별 소비 조회", description = "무한 스크롤을 통한 조회로 예상하여 Slice를 통해서 조회")
 	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-		@ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-		@ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
-	ResponseEntity<MonthlyExpenseCompactResponseDto> findExpensesForMonth(Pageable pageable, Long userId,
-		LocalDate date);
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+			@ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+			@ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
+	ResponseEntity<MonthlyExpenseCompactResponseDto> findExpensesForMonth(Pageable pageable, Long userId, LocalDate date);
 
 	@Operation(summary = "단일 소비 조회하기", description = "queryParameter를 통해 소비 Id를 전달 받아서 응답값을 조회")
 	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-		@ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-		@ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+			@ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+			@ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
 	@GetMapping("/{userId}/{expenseId}")
 	ResponseEntity<ExpenseResponseDto> findExpense(@Param("userId") Long userId, @Param("expenseId") Long expenseId);
 
 	@PostMapping("/{userId}")
-	ResponseEntity<ExpenseResponseDto> updateExpense(@PathVariable @Param("userId") Long userId,
-		@RequestBody ExpenseUpdateRequestDto request);
+	ResponseEntity<ExpenseResponseDto> updateExpense(@PathVariable @Param("userId") Long userId, @RequestBody ExpenseUpdateRequestDto request);
 
+	@Operation(summary = "소비 내역 삭제", description = "사용자가 소비 내역을 삭제합니다.")
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+	})
+	@DeleteMapping("/delete/{expenseId}")
+	ResponseEntity<String> deleteExpense(@Parameter(description = "expense_id") @PathVariable Long expenseId);
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/ExpenseController.java
@@ -7,13 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseRequestDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseUpdateRequestDto;
@@ -30,7 +24,8 @@ public class ExpenseController implements ExpenseApi {
 	@Override
 	@PostMapping("/add")
 	public ResponseEntity<ExpenseResponseDto> createExpense(
-			@Parameter(description = "user_id, category_id, amount, description, expenseDate") @RequestBody ExpenseRequestDto expenseRequestDto) {
+			@Parameter(description = "user_id, category_id, amount, description, expenseDate")
+			@RequestBody ExpenseRequestDto expenseRequestDto) {
 		ExpenseResponseDto response = expenseService.createExpense(expenseRequestDto);
 		return ResponseEntity.ok(response);
 	}
@@ -47,17 +42,23 @@ public class ExpenseController implements ExpenseApi {
 	@Override
 	@GetMapping("/{userId}/{expenseId}")
 	public ResponseEntity<ExpenseResponseDto> findExpense(@PathVariable @Param("userId") Long userId,
-		@PathVariable @Param("expenseId") Long expenseId) {
-
+														  @PathVariable @Param("expenseId") Long expenseId) {
 		return ResponseEntity.ok(expenseService.findExpenseResponseFromUserIdAndExpenseId(userId, expenseId));
 	}
 
 	@Override
 	@PostMapping("/{userId}")
 	public ResponseEntity<ExpenseResponseDto> updateExpense(@PathVariable @Param("userId") Long userId,
-		@RequestBody ExpenseUpdateRequestDto request) {
+															@RequestBody ExpenseUpdateRequestDto request) {
 		ExpenseResponseDto response = expenseService.updateExpense(userId, request);
-
 		return ResponseEntity.ok(response);
+	}
+
+	@DeleteMapping("/delete/{expenseId}")
+	public ResponseEntity<String> deleteExpense(
+			@Parameter(description = "expense_id")
+			@PathVariable Long expenseId) {
+		expenseService.deleteExpense(expenseId);
+		return ResponseEntity.ok("Successfully deleted expense!");
 	}
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseService.java
@@ -17,4 +17,6 @@ public interface ExpenseService {
 	ExpenseResponseDto findExpenseResponseFromUserIdAndExpenseId(Long userId, Long expenseId);
 
 	ExpenseResponseDto updateExpense(Long userId, ExpenseUpdateRequestDto request);
+
+	void deleteExpense(Long expenseId);
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseServiceImpl.java
@@ -53,7 +53,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 		}
         /*
          Case 2)
-         !default && 키테고리 테이블의 UserId 컬럼의 값이 나와 맞으면 (= custom cateogory)
+         !default && 키테고리 테이블의 UserId 컬럼의 값이 나와 맞으면 (= custom category)
          */
 		else if (!category.getIsDefault() && category.getUser().getId().equals(expenseRequestDto.getUserId())) {
 			// custom category
@@ -94,6 +94,23 @@ public class ExpenseServiceImpl implements ExpenseService {
          결과 Case 1) 해당 유저의 user_id + immutable 필드 중 하나의 조합으로 Expense 테이블에 저장
          결과 Case 2) 내가 직접 생성한 카테고리 중 하나로 카테고리를 설정하여 Expense 테이블에 저장
          */
+	}
+
+
+	@Override
+	public void deleteExpense(Long expenseId) {
+		Expense expense = expenseRepository.findById(expenseId)
+				.orElseThrow(() -> new IllegalArgumentException("Not found Expense"));
+
+		Long userId = expense.getUser().getId();
+		Long categoryId = expense.getCategory().getId();
+		Long amount = expense.getAmount();
+		LocalDate expenseDate = expense.getExpenseDate().toLocalDate();
+
+		expenseRepository.delete(expense);
+
+		// 소비 금액 차감 로직
+		consumptionGoalService.decreaseConsumeAmount(userId, categoryId, amount, expenseDate);
 	}
 
 	@Override


### PR DESCRIPTION
## 개요
- 소비 내역 삭제 -> expense의 delete 컬럼 true
- consumptionGoal에 해당되는 필드 --consumeAmount

## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.
- [ ] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
