### PR TITLE
[test] 소비 업데이트시 소비목표의 변경되는 소비총액 테스트

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/ExpenseUpdateRequestDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/ExpenseUpdateRequestDto.java
@@ -3,11 +3,15 @@ package com.bbteam.budgetbuddies.domain.expense.dto;
 import java.time.LocalDateTime;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Builder
 public class ExpenseUpdateRequestDto {
 	private Long expenseId;
 	private Long categoryId;

--- a/src/test/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceTest.java
+++ b/src/test/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -35,6 +36,8 @@ import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.TopConsumptionRespons
 import com.bbteam.budgetbuddies.domain.consumptiongoal.dto.TopGoalCategoryResponseDTO;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.entity.ConsumptionGoal;
 import com.bbteam.budgetbuddies.domain.consumptiongoal.repository.ConsumptionGoalRepository;
+import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseUpdateRequestDto;
+import com.bbteam.budgetbuddies.domain.expense.entity.Expense;
 import com.bbteam.budgetbuddies.domain.user.entity.User;
 import com.bbteam.budgetbuddies.domain.user.repository.UserRepository;
 import com.bbteam.budgetbuddies.enums.Gender;
@@ -70,7 +73,6 @@ class ConsumptionGoalServiceTest {
 			.gender(Gender.MALE)
 			.phoneNumber("010-1234-5678")
 			.build());
-		given(user.getId()).willReturn(-1L);
 	}
 
 	@Test
@@ -393,8 +395,10 @@ class ConsumptionGoalServiceTest {
 	void getTopConsumptionCategories_Success() {
 		// given
 		Category defaultCategory = Mockito.spy(Category.builder().name("디폴트 카테고리").user(null).isDefault(true).build());
-		Category defaultCategory2 = Mockito.spy(Category.builder().name("디폴트 카테고리2").user(null).isDefault(true).build());
-		Category defaultCategory3 = Mockito.spy(Category.builder().name("디폴트 카테고리3").user(null).isDefault(true).build());
+		Category defaultCategory2 = Mockito.spy(
+			Category.builder().name("디폴트 카테고리2").user(null).isDefault(true).build());
+		Category defaultCategory3 = Mockito.spy(
+			Category.builder().name("디폴트 카테고리3").user(null).isDefault(true).build());
 
 		ConsumptionGoal topConsumptionGoal1 = ConsumptionGoal.builder()
 			.goalAmount(5000L)
@@ -425,7 +429,8 @@ class ConsumptionGoalServiceTest {
 			List.of(topConsumptionGoal1, topConsumptionGoal2, topConsumptionGoal3));
 
 		// when
-		List<TopConsumptionResponseDTO> result = consumptionGoalService.getTopConsumption(3, user.getId(), 23, 25, "MALE");
+		List<TopConsumptionResponseDTO> result = consumptionGoalService.getTopConsumption(3, user.getId(), 23, 25,
+			"MALE");
 
 		// then
 		assertThat(result).hasSize(3);
@@ -435,5 +440,55 @@ class ConsumptionGoalServiceTest {
 		assertThat(result.get(1).getConsumeAmount()).isEqualTo(topConsumptionGoal2.getConsumeAmount());
 		assertThat(result.get(2).getCategoryName()).isEqualTo(defaultCategory3.getName());
 		assertThat(result.get(2).getConsumeAmount()).isEqualTo(topConsumptionGoal3.getConsumeAmount());
+	}
+
+	@Test
+	@DisplayName("지난 달, 이번 달 소비 목표가 없는 카테고리에 대한 소비 업데이트를 진행하는 경우 새로운 소비 목표를 생성해 소비 금액을 갱신")
+	void recalculateConsumptionAmount_notExistPreviousMonthAndThisMonthGoal() {
+		// given
+		Category existGoalCategory = Category.builder().name("유저 카테고리").user(user).isDefault(false).build();
+		Category notExistGoalCategory = Mockito.spy(Category.builder().name("디폴트 카테고리").isDefault(true).build());
+		given(notExistGoalCategory.getId()).willReturn(-1L);
+
+		Expense expense = Mockito.spy(
+			Expense.builder().category(existGoalCategory).expenseDate(GOAL_MONTH.atStartOfDay()).amount(1000L).build());
+		when(expense.getId()).thenReturn(-1L);
+
+		ExpenseUpdateRequestDto request = ExpenseUpdateRequestDto.builder()
+			.amount(1000L)
+			.expenseId(expense.getId())
+			.expenseDate(LocalDate.of(2024, 8, 07).atStartOfDay())
+			.categoryId(notExistGoalCategory.getId())
+			.build();
+
+		ConsumptionGoal oldGoal = ConsumptionGoal.builder().consumeAmount(1000L).category(existGoalCategory).build();
+		ConsumptionGoal expected = ConsumptionGoal.builder()
+			.goalMonth(LocalDate.of(2024, 8, 1))
+			.goalAmount(0L)
+			.consumeAmount(1000L)
+			.category(notExistGoalCategory)
+			.user(user)
+			.build();
+		// when
+		when(consumptionGoalRepository.findConsumptionGoalByUserAndCategoryAndGoalMonth(user, expense.getCategory(),
+			expense.getExpenseDate().toLocalDate().withDayOfMonth(1))).thenReturn(Optional.ofNullable(oldGoal));
+
+		when(categoryRepository.findById(request.getCategoryId())).thenReturn(Optional.of(notExistGoalCategory));
+		when(consumptionGoalRepository.findConsumptionGoalByUserAndCategoryAndGoalMonth(user, notExistGoalCategory,
+			request.getExpenseDate().toLocalDate().withDayOfMonth(1))).thenReturn(Optional.empty());
+
+		when(consumptionGoalRepository.findConsumptionGoalByUserAndCategoryAndGoalMonth(user, notExistGoalCategory,
+			request.getExpenseDate().minusMonths(1).toLocalDate().withDayOfMonth(1))).thenReturn(Optional.empty());
+
+		consumptionGoalService.recalculateConsumptionAmount(expense, request, user);
+
+		ArgumentCaptor<ConsumptionGoal> consumptionGoalCaptor = ArgumentCaptor.forClass(ConsumptionGoal.class);
+		verify(consumptionGoalRepository, times(2)).save(consumptionGoalCaptor.capture());
+
+		List<ConsumptionGoal> savedConsumptionGoals = consumptionGoalCaptor.getAllValues();
+
+		// then
+		assertEquals(oldGoal.getConsumeAmount(), 0L);
+		assertThat(savedConsumptionGoals.get(1)).usingRecursiveComparison().isEqualTo(expected);
 	}
 }


### PR DESCRIPTION
## 개요
-  지난 달, 이번 달 소비 목표가 없는 카테고리에 대한 소비 업데이트를 진행하는 경우 새로운 소비 목표를 생성해 소비 금액을 갱신한다.
-  이번달 소비 목표가 없는 카테고리에 대한 소비 업데이트를 진행하는 경우 지난 달 소비 목표의 목표 금액을 복사한 이번 달 소비 목표를 생성 소비 금액을 갱신한다.
-  이번달 소비 목표가 있는 경우 이번 달 소비 목표의 소비 금액을 갱신한다.

## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
