### PR TITLE
[feat] 사용자의 소비목표 조회 내림차순 및 남은 소비금액 구현

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/converter/ConsumptionGoalConverter.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/converter/ConsumptionGoalConverter.java
@@ -33,13 +33,16 @@ public class ConsumptionGoalConverter {
 
 	public ConsumptionGoalResponseListDto toConsumptionGoalResponseListDto(
 		List<ConsumptionGoalResponseDto> consumptionGoalList, LocalDate goalMonth) {
+		Long totalGoalAmount = sumTotalGoalAmount(consumptionGoalList);
+		Long totalConsumptionAmount = sumTotalConsumptionAmount(consumptionGoalList);
+
 		return ConsumptionGoalResponseListDto.builder()
 			.goalMonth(goalMonth)
-			.totalGoalAmount(sumTotalGoalAmount(consumptionGoalList))
-			.totalConsumptionAmount(sumTotalConsumptionAmount(consumptionGoalList))
+			.totalGoalAmount(totalGoalAmount)
+			.totalConsumptionAmount(totalConsumptionAmount)
+			.totalRemainingBalance(totalGoalAmount - totalConsumptionAmount)
 			.consumptionGoalList(consumptionGoalList)
 			.build();
-
 	}
 
 	private Long sumTotalConsumptionAmount(List<ConsumptionGoalResponseDto> consumptionGoalList) {

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalResponseDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalResponseDto.java
@@ -9,6 +9,7 @@ public class ConsumptionGoalResponseDto {
 	private Long categoryId;
 	private Long goalAmount;
 	private Long consumeAmount;
+	private Long remainingBalance;
 
 	@Builder
 	public ConsumptionGoalResponseDto(String categoryName, Long categoryId, Long goalAmount, Long consumeAmount) {
@@ -16,5 +17,6 @@ public class ConsumptionGoalResponseDto {
 		this.categoryId = categoryId;
 		this.goalAmount = goalAmount;
 		this.consumeAmount = consumeAmount;
+		this.remainingBalance = goalAmount - consumeAmount;
 	}
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalResponseListDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/dto/ConsumptionGoalResponseListDto.java
@@ -17,5 +17,6 @@ public class ConsumptionGoalResponseListDto {
 	private LocalDate goalMonth;
 	private Long totalGoalAmount;
 	private Long totalConsumptionAmount;
+	private Long totalRemainingBalance;
 	private List<ConsumptionGoalResponseDto> consumptionGoalList;
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalServiceImpl.java
@@ -4,6 +4,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -197,7 +198,10 @@ public class ConsumptionGoalServiceImpl implements ConsumptionGoalService {
 		updateGoalMapWithPreviousMonth(userId, goalMonth, goalMap);
 		updateGoalMapWithCurrentMonth(userId, goalMonth, goalMap);
 
-		return consumptionGoalConverter.toConsumptionGoalResponseListDto(new ArrayList<>(goalMap.values()), goalMonth);
+		List<ConsumptionGoalResponseDto> consumptionGoalList = new ArrayList<>(goalMap.values());
+
+		return consumptionGoalConverter.toConsumptionGoalResponseListDto(
+			orderByRemainingBalanceDescending(consumptionGoalList), goalMonth);
 	}
 
 	private Map<Long, ConsumptionGoalResponseDto> initializeGoalMap(Long userId) {
@@ -221,6 +225,13 @@ public class ConsumptionGoalServiceImpl implements ConsumptionGoalService {
 			.stream()
 			.map(consumptionGoalConverter::toConsumptionGoalResponseDto)
 			.forEach(goal -> goalMap.put(goal.getCategoryId(), goal));
+	}
+
+	private List<ConsumptionGoalResponseDto> orderByRemainingBalanceDescending(
+		List<ConsumptionGoalResponseDto> consumptionGoalList) {
+		return consumptionGoalList.stream()
+			.sorted(Comparator.comparingLong(ConsumptionGoalResponseDto::getRemainingBalance).reversed())
+			.toList();
 	}
 
 	@Override


### PR DESCRIPTION
## 개요
<img width="449" alt="image" src="https://github.com/user-attachments/assets/dae5151d-cd55-4bfb-9814-7f792ec5fe17">

- 메인페이지에 잔여 금액을 보여주는 화면이 존재
- 메인페이지는 잔여 금액의 내림차순에 따른 상위 4개 금액을 보여주기 때문에 내림차순 정렬이 필요

## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
