### PR TITLE
[FIX] expense 조회시 카테고리도 함께 반환되도록 구현

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/converter/ExpenseConverter.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/converter/ExpenseConverter.java
@@ -59,6 +59,7 @@ public class ExpenseConverter {
 			.description(expense.getDescription())
 			.amount(expense.getAmount())
 			.expenseDate(expense.getExpenseDate())
+			.categoryId(expense.getCategory().getId())
 			.build();
 	}
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/CompactExpenseResponseDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/CompactExpenseResponseDto.java
@@ -18,6 +18,7 @@ public class CompactExpenseResponseDto {
 	private Long expenseId;
 	private String description;
 	private Long amount;
+	private Long categoryId;
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
 	private LocalDateTime expenseDate;

--- a/src/test/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseServiceImplTest.java
+++ b/src/test/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseServiceImplTest.java
@@ -66,6 +66,7 @@ class ExpenseServiceImplTest {
 		given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
 		Category userCategory = Mockito.spy(Category.builder().build());
+		given(userCategory.getId()).willReturn(-1L);
 
 		LocalDate requestMonth = LocalDate.of(2024, 07, 8);
 		Pageable requestPage = PageRequest.of(0, pageSize);
@@ -120,6 +121,7 @@ class ExpenseServiceImplTest {
 				.expenseId((long)-i)
 				.expenseDate(month.withDayOfMonth(i).atStartOfDay())
 				.amount(i * 100000L)
+				.categoryId(-1L)
 				.build());
 		}
 		return compactExpenses;


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
expense 조회시 카테고리 정보가 반환되지 않은 문제에 대한 해결

## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.
- [ ] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [ ] 기존의 코드에 영향이 없는 것을 확인했습니다.
