### PR TITLE
[feat] 카테고리 삭제 기능 구현

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/common/BaseEntity.java
+++ b/src/main/java/com/bbteam/budgetbuddies/common/BaseEntity.java
@@ -2,10 +2,7 @@ package com.bbteam.budgetbuddies.common;
 
 import jakarta.persistence.*;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.*;
@@ -22,6 +19,7 @@ import java.time.LocalDateTime;
 @SuperBuilder
 @SoftDelete(columnName = "deleted") // boolean 타입의 deleted 필드가 추가
 @Getter
+@Setter
 public abstract class BaseEntity {
 
     @Id

--- a/src/main/java/com/bbteam/budgetbuddies/domain/category/controller/CategoryApi.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/category/controller/CategoryApi.java
@@ -4,6 +4,7 @@ import com.bbteam.budgetbuddies.domain.category.dto.CategoryRequestDTO;
 import com.bbteam.budgetbuddies.domain.category.dto.CategoryResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -38,4 +39,20 @@ public interface CategoryApi {
     })
     @GetMapping("/get/{userId}")
     ResponseEntity<List<CategoryResponseDTO>> getUserCategories(@PathVariable Long userId);
+
+    @Operation(summary = "특정 카테고리 삭제하기 API", description = "특정 카테고리를 삭제하는 API이며, 사용자의 ID를 입력하여 사용합니다. (추후 토큰으로 검증)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "해당하는 사용자의 id"),
+            @Parameter(name = "categoryId", description = "삭제할 카테고리의 id"),
+    })
+    ResponseEntity<String> deleteCategory(
+            @RequestParam Long userId,
+            @PathVariable Long categoryId
+    );
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/category/controller/CategoryController.java
@@ -3,12 +3,7 @@ package com.bbteam.budgetbuddies.domain.category.controller;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.bbteam.budgetbuddies.domain.category.dto.CategoryRequestDTO;
 import com.bbteam.budgetbuddies.domain.category.dto.CategoryResponseDTO;
@@ -32,10 +27,19 @@ public class CategoryController implements CategoryApi {
 		return ResponseEntity.ok(response);
 	}
 
-	@Override
-	@GetMapping("/get/{userId}")
-	public ResponseEntity<List<CategoryResponseDTO>> getUserCategories(@PathVariable Long userId) {
-		List<CategoryResponseDTO> response = categoryService.getUserCategories(userId);
-		return ResponseEntity.ok(response);
-	}
+    @Override
+    @GetMapping("/get/{userId}")
+    public ResponseEntity<List<CategoryResponseDTO>> getUserCategories(@PathVariable Long userId) {
+        List<CategoryResponseDTO> response = categoryService.getUserCategories(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @DeleteMapping("/delete/{categoryId}")
+    public ResponseEntity<String> deleteCategory(
+            @RequestParam Long userId,
+            @PathVariable Long categoryId) {
+        categoryService.deleteCategory(categoryId, userId);
+        return ResponseEntity.ok("Successfully deleted category!");
+    }
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/category/entity/Category.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/category/entity/Category.java
@@ -1,6 +1,5 @@
 package com.bbteam.budgetbuddies.domain.category.entity;
 
-import com.bbteam.budgetbuddies.common.BaseEntity;
 import com.bbteam.budgetbuddies.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -24,8 +23,11 @@ public class Category {
     @ColumnDefault("1")
     private Boolean isDefault;
 
+    @Column(nullable = false)
+    @ColumnDefault("false")
+    private Boolean deleted = false;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
-
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/category/repository/CategoryRepository.java
@@ -1,6 +1,7 @@
 package com.bbteam.budgetbuddies.domain.category.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +16,5 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 	@Query("SELECT c FROM Category c WHERE c.isDefault = true")
 	List<Category> findAllByIsDefaultTrue();
 	boolean existsByUserIdAndName(Long userId, String name);
+	Optional<Category> findById(Long id);
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/category/service/CategoryService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/category/service/CategoryService.java
@@ -15,5 +15,7 @@ public interface CategoryService {
 	List<CategoryResponseDTO> getUserCategories(Long userId);
 
 	Category handleCategoryChange(Expense expense, ExpenseUpdateRequestDto request, User user);
+
+	void deleteCategory(Long id, Long userId);
 }
 

--- a/src/main/java/com/bbteam/budgetbuddies/domain/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/category/service/CategoryServiceImpl.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.bbteam.budgetbuddies.domain.expense.repository.ExpenseRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +33,7 @@ public class CategoryServiceImpl implements CategoryService {
 	private final UserRepository userRepository;
 	private final CategoryConverter categoryConverter;
 	private final ConsumptionGoalRepository consumptionGoalRepository;
+	private final ExpenseRepository expenseRepository;
 
 	@Override
 	public CategoryResponseDTO createCategory(Long userId, CategoryRequestDTO categoryRequestDTO) {
@@ -62,7 +64,7 @@ public class CategoryServiceImpl implements CategoryService {
 	public List<CategoryResponseDTO> getUserCategories(Long userId) {
 
 		userRepository.findById(userId)
-			.orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
+				.orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
 
 		List<Category> categories = categoryRepository.findUserCategoryByUserId(userId);
 		return categories.stream().map(categoryConverter::toCategoryResponseDTO).collect(Collectors.toList());
@@ -72,11 +74,44 @@ public class CategoryServiceImpl implements CategoryService {
 	@Transactional(readOnly = true)
 	public Category handleCategoryChange(Expense expense, ExpenseUpdateRequestDto request, User user) {
 		Category categoryToReplace = categoryRepository.findById(request.getCategoryId())
-			.orElseThrow(() -> new IllegalArgumentException("Not found category"));
+				.orElseThrow(() -> new IllegalArgumentException("Not found category"));
 
 		consumptionGoalService.recalculateConsumptionAmount(expense, request, user);
 
 		return categoryToReplace;
 	}
 
+	@Override
+	@Transactional
+	public void deleteCategory(Long categoryId, Long userId) {
+		categoryRepository.findById(categoryId).ifPresent(category -> {
+			if (category.getIsDefault()) {
+				throw new IllegalArgumentException("Default categories cannot be deleted.");
+			}
+
+			List<Expense> expenses = expenseRepository.findByCategoryIdAndUserId(categoryId, userId);
+			long totalAmount = expenses.stream().mapToLong(Expense::getAmount).sum();
+
+			Category etcCategory = categoryRepository.findById(10L)
+					.orElseThrow(() -> new IllegalArgumentException("etc category not found"));
+
+			expenses.forEach(expense -> {
+				expense.setCategory(etcCategory);
+				expenseRepository.save(expense);
+			});
+
+			ConsumptionGoal goal = consumptionGoalRepository.findByCategoryIdAndUserId(10L, userId)
+					.orElseThrow(() -> new IllegalArgumentException("No consumption goal found for category_id 10."));
+			goal.setConsumeAmount(goal.getConsumeAmount() + totalAmount);
+			consumptionGoalRepository.save(goal);
+
+			consumptionGoalRepository.findByCategoryIdAndUserId(categoryId, userId).ifPresent(consumptionGoal -> {
+				consumptionGoal.setDeleted(true);
+				consumptionGoalRepository.save(consumptionGoal);
+			});
+
+			category.setDeleted(true);
+			categoryRepository.save(category);
+		});
+	}
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/entity/ConsumptionGoal.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/entity/ConsumptionGoal.java
@@ -12,15 +12,13 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.Min;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @SuperBuilder

--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/repository/ConsumptionGoalRepository.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/repository/ConsumptionGoalRepository.java
@@ -23,61 +23,84 @@ public interface ConsumptionGoalRepository extends JpaRepository<ConsumptionGoal
 	@Query(value = "SELECT cg FROM ConsumptionGoal AS cg WHERE cg.user.id = :userId AND cg.goalMonth = :goalMonth")
 	List<ConsumptionGoal> findConsumptionGoalByUserIdAndGoalMonth(Long userId, LocalDate goalMonth);
 
-	Optional<ConsumptionGoal> findConsumptionGoalByUserAndCategoryAndGoalMonth(User user, Category category,
-		LocalDate goalMonth);
+	Optional<ConsumptionGoal> findConsumptionGoalByUserAndCategoryAndGoalMonth(User user, Category category, LocalDate goalMonth);
 
-	@Query("SELECT AVG(cg.consumeAmount) FROM ConsumptionGoal cg " + "JOIN cg.category c " + "WHERE c.id = :categoryId "
-		+ "AND cg.goalMonth BETWEEN :startOfWeek AND :endOfWeek "
-		+ "AND cg.user.age BETWEEN :peerAgeStart AND :peerAgeEnd " + "AND cg.user.gender = :peerGender")
+	@Query("SELECT AVG(cg.consumeAmount) FROM ConsumptionGoal cg " +
+			"JOIN cg.category c " +
+			"WHERE c.id = :categoryId " +
+			"AND cg.goalMonth BETWEEN :startOfWeek AND :endOfWeek " +
+			"AND cg.user.age BETWEEN :peerAgeStart AND :peerAgeEnd " +
+			"AND cg.user.gender = :peerGender")
 	Optional<Long> findAvgConsumptionByCategoryIdAndCurrentWeek(
-		@Param("categoryId") Long categoryId, @Param("startOfWeek") LocalDate startOfWeek,
-		@Param("endOfWeek") LocalDate endOfWeek, @Param("peerAgeStart") int peerAgeStart,
-		@Param("peerAgeEnd") int peerAgeEnd, @Param("peerGender") Gender peerGender);
+			@Param("categoryId") Long categoryId,
+			@Param("startOfWeek") LocalDate startOfWeek,
+			@Param("endOfWeek") LocalDate endOfWeek,
+			@Param("peerAgeStart") int peerAgeStart,
+			@Param("peerAgeEnd") int peerAgeEnd,
+			@Param("peerGender") Gender peerGender);
 
-	@Query(
-		"SELECT new com.bbteam.budgetbuddies.domain.consumptiongoal.dto.AvgConsumptionGoalDto("
-			+ "cg.category.id, AVG(cg.consumeAmount))"
-			+ "FROM ConsumptionGoal cg " + "WHERE cg.category.isDefault = true "
-			+ "AND cg.user.age BETWEEN :peerAgeStart AND :peerAgeEnd " + "AND cg.user.gender = :peerGender "
-			+ "AND cg.goalMonth >= :currentMonth " + "GROUP BY cg.category.id " + "ORDER BY AVG(cg.consumeAmount) DESC")
+	@Query("SELECT new com.bbteam.budgetbuddies.domain.consumptiongoal.dto.AvgConsumptionGoalDto(" +
+			"cg.category.id, AVG(cg.consumeAmount))" +
+			"FROM ConsumptionGoal cg " +
+			"WHERE cg.category.isDefault = true " +
+			"AND cg.user.age BETWEEN :peerAgeStart AND :peerAgeEnd " +
+			"AND cg.user.gender = :peerGender " +
+			"AND cg.goalMonth >= :currentMonth " +
+			"GROUP BY cg.category.id " +
+			"ORDER BY AVG(cg.consumeAmount) DESC")
 	List<AvgConsumptionGoalDto> findAvgConsumptionAmountByCategory(
-		@Param("peerAgeStart") int peerAgeStart,
-		@Param("peerAgeEnd") int peerAgeEnd,
-		@Param("peerGender") Gender peerGender,
-		@Param("currentMonth") LocalDate currentMonth);
+			@Param("peerAgeStart") int peerAgeStart,
+			@Param("peerAgeEnd") int peerAgeEnd,
+			@Param("peerGender") Gender peerGender,
+			@Param("currentMonth") LocalDate currentMonth);
 
-	@Query("SELECT new com.bbteam.budgetbuddies.domain.consumptiongoal.dto.MyConsumptionGoalDto("
-		+ "cg.category.id, SUM(cg.consumeAmount)) " + "FROM ConsumptionGoal cg "
-		+ "WHERE cg.category.isDefault = true " + "AND cg.user.id = :userId "
-		+ "GROUP BY cg.category.id " + "ORDER BY cg.category.id")
+	@Query("SELECT new com.bbteam.budgetbuddies.domain.consumptiongoal.dto.MyConsumptionGoalDto(" +
+			"cg.category.id, SUM(cg.consumeAmount)) " +
+			"FROM ConsumptionGoal cg " +
+			"WHERE cg.category.isDefault = true " +
+			"AND cg.user.id = :userId " +
+			"GROUP BY cg.category.id " +
+			"ORDER BY cg.category.id")
 	List<MyConsumptionGoalDto> findAllConsumptionAmountByUserId(@Param("userId") Long userId);
 
-	@Query(
-		"SELECT new com.bbteam.budgetbuddies.domain.consumptiongoal.dto.AvgConsumptionGoalDto(cg.category.id, AVG("
-			+ "cg.goalAmount))"
-			+ "FROM ConsumptionGoal cg " + "WHERE cg.category.isDefault = true "
-			+ "AND cg.user.age BETWEEN :peerAgeStart AND :peerAgeEnd " + "AND cg.user.gender = :peerGender "
-			+ "AND cg.goalMonth >= :currentMonth " + "GROUP BY cg.category.id " + "ORDER BY AVG(cg.goalAmount) DESC")
+	@Query("SELECT new com.bbteam.budgetbuddies.domain.consumptiongoal.dto.AvgConsumptionGoalDto(" +
+			"cg.category.id, AVG(cg.goalAmount))" +
+			"FROM ConsumptionGoal cg " +
+			"WHERE cg.category.isDefault = true " +
+			"AND cg.user.age BETWEEN :peerAgeStart AND :peerAgeEnd " +
+			"AND cg.user.gender = :peerGender " +
+			"AND cg.goalMonth >= :currentMonth " +
+			"GROUP BY cg.category.id " +
+			"ORDER BY AVG(cg.goalAmount) DESC")
 	List<AvgConsumptionGoalDto> findAvgGoalAmountByCategory(
-		@Param("peerAgeStart") int peerAgeStart,
-		@Param("peerAgeEnd") int peerAgeEnd,
-		@Param("peerGender") Gender peerGender,
-		@Param("currentMonth") LocalDate currentMonth);
+			@Param("peerAgeStart") int peerAgeStart,
+			@Param("peerAgeEnd") int peerAgeEnd,
+			@Param("peerGender") Gender peerGender,
+			@Param("currentMonth") LocalDate currentMonth);
 
-	@Query("SELECT new com.bbteam.budgetbuddies.domain.consumptiongoal.dto.MyConsumptionGoalDto("
-		+ "cg.category.id, SUM(cg.goalAmount)) " + "FROM ConsumptionGoal cg "
-		+ "WHERE cg.category.isDefault = true " + "AND cg.user.id = :userId "
-		+ "GROUP BY cg.category.id " + "ORDER BY cg.category.id")
+	@Query("SELECT new com.bbteam.budgetbuddies.domain.consumptiongoal.dto.MyConsumptionGoalDto(" +
+			"cg.category.id, SUM(cg.goalAmount)) " +
+			"FROM ConsumptionGoal cg " +
+			"WHERE cg.category.isDefault = true " +
+			"AND cg.user.id = :userId " +
+			"GROUP BY cg.category.id " +
+			"ORDER BY cg.category.id")
 	List<MyConsumptionGoalDto> findAllGoalAmountByUserId(@Param("userId") Long userId);
 
-	@Query(
-		"SELECT new com.bbteam.budgetbuddies.domain.consumptiongoal.dto.CategoryConsumptionCountDto("
-			+ "cg.category.id, COUNT(cg)) " + "FROM ConsumptionGoal cg " + "WHERE cg.category.isDefault = true "
-			+ "AND cg.user.age BETWEEN :peerAgeStart AND :peerAgeEnd " + "AND cg.user.gender = :peerGender "
-			+ "AND cg.goalMonth >= :currentMonth " + "GROUP BY cg.category.id " + "ORDER BY COUNT(cg) DESC")
+	@Query("SELECT new com.bbteam.budgetbuddies.domain.consumptiongoal.dto.CategoryConsumptionCountDto(" +
+			"cg.category.id, COUNT(cg)) " +
+			"FROM ConsumptionGoal cg " +
+			"WHERE cg.category.isDefault = true " +
+			"AND cg.user.age BETWEEN :peerAgeStart AND :peerAgeEnd " +
+			"AND cg.user.gender = :peerGender " +
+			"AND cg.goalMonth >= :currentMonth " +
+			"GROUP BY cg.category.id " +
+			"ORDER BY COUNT(cg) DESC")
 	List<CategoryConsumptionCountDto> findTopCategoriesByConsumptionCount(
-		@Param("peerAgeStart") int peerAgeStart,
-		@Param("peerAgeEnd") int peerAgeEnd,
-		@Param("peerGender") Gender peerGender,
-		@Param("currentMonth") LocalDate currentMonth);
+			@Param("peerAgeStart") int peerAgeStart,
+			@Param("peerAgeEnd") int peerAgeEnd,
+			@Param("peerGender") Gender peerGender,
+			@Param("currentMonth") LocalDate currentMonth);
+
+	Optional<ConsumptionGoal> findByCategoryIdAndUserId(Long categoryId, Long userId);
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/entity/Expense.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/entity/Expense.java
@@ -13,14 +13,12 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.Min;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @SuperBuilder

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/repository/ExpenseRepository.java
@@ -16,4 +16,6 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 	@Query("SELECT e FROM Expense e WHERE e.user = :user AND e.expenseDate BETWEEN :startDate AND :endDate ORDER BY e.expenseDate DESC")
 	Slice<Expense> findAllByUserIdForPeriod(Pageable pageable, @Param("user") User user,
 											@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+	List<Expense> findByCategoryIdAndUserId(Long categoryId, Long userId);
 }


### PR DESCRIPTION
## 개요
> 유저가 추가한 카테고리를 삭제하는 API
1) default 카테고리 여부 확인
2) 삭제하고자하는 카테고리에 대한 expense 모두 가져오기 (추후 consumptionGoal의 consumeAmount 업데이트에 사용)
3) 삭제하고자하는 카테고리에 해당하는 expense 필드들의 category_id를 10으로 변경(default 카테고리의 "기타")
4) 삭제하고자하는 카테고리에 해당하는 consumptionGoal의 category_id를 10으로 변경(default 카테고리의 "기타")
5) 각 엔티티의 deleted 컬럼 true로 업데이트

## 추후 필수 진행 사항
- consumptionGoal의 deleted = true 변경 이슈 해결

## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
