### PR TITLE
[feat] 월별 소비 조회 전체 소비금액 구현 및 일별 반환 #131

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/ExpenseApi.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/ExpenseApi.java
@@ -1,50 +1,55 @@
 package com.bbteam.budgetbuddies.domain.expense.controller;
 
 import java.time.LocalDate;
-import org.springframework.data.domain.Pageable;
+
 import org.springframework.data.repository.query.Param;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseRequestDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseUpdateRequestDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.MonthlyExpenseCompactResponseDto;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import org.springframework.web.bind.annotation.DeleteMapping;
 
 public interface ExpenseApi {
 	@Operation(summary = "소비 내역 추가", description = "사용자가 소비 내역을 추가합니다.")
 	@ApiResponses({
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-			@ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-			@ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+		@ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+		@ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
 	ResponseEntity<ExpenseResponseDto> createExpense(
-			@Parameter(description = "user_id, category_id, amount, description, expenseDate") ExpenseRequestDto expenseRequestDto);
+		@Parameter(description = "user_id, category_id, amount, description, expenseDate") ExpenseRequestDto expenseRequestDto);
 
 	@Operation(summary = "월별 소비 조회", description = "무한 스크롤을 통한 조회로 예상하여 Slice를 통해서 조회")
 	@ApiResponses({
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-			@ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-			@ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
-	ResponseEntity<MonthlyExpenseCompactResponseDto> findExpensesForMonth(Pageable pageable, Long userId, LocalDate date);
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+		@ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+		@ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
+	ResponseEntity<MonthlyExpenseCompactResponseDto> findExpensesForMonth(
+		@PathVariable @Param("userId") Long userId,
+		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date);
 
 	@Operation(summary = "단일 소비 조회하기", description = "queryParameter를 통해 소비 Id를 전달 받아서 응답값을 조회")
 	@ApiResponses({
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-			@ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-			@ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+		@ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+		@ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
 	@GetMapping("/{userId}/{expenseId}")
 	ResponseEntity<ExpenseResponseDto> findExpense(@Param("userId") Long userId, @Param("expenseId") Long expenseId);
 
@@ -56,14 +61,15 @@ public interface ExpenseApi {
 		@ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
 	@GetMapping("/{userId}/{expenseId}")
 	@PostMapping("/{userId}")
-	ResponseEntity<ExpenseResponseDto> updateExpense(@PathVariable @Param("userId") Long userId, @RequestBody ExpenseUpdateRequestDto request);
+	ResponseEntity<ExpenseResponseDto> updateExpense(@PathVariable @Param("userId") Long userId,
+		@RequestBody ExpenseUpdateRequestDto request);
 
 	@Operation(summary = "소비 내역 삭제", description = "사용자가 소비 내역을 삭제합니다.")
 	@ApiResponses({
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
 	})
 	@DeleteMapping("/delete/{expenseId}")
 	ResponseEntity<String> deleteExpense(@Parameter(description = "expense_id") @PathVariable Long expenseId);

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/ExpenseController.java
@@ -2,17 +2,25 @@ package com.bbteam.budgetbuddies.domain.expense.controller;
 
 import java.time.LocalDate;
 
-import io.swagger.v3.oas.annotations.Parameter;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseRequestDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseUpdateRequestDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.MonthlyExpenseCompactResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.service.ExpenseService;
+
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -24,40 +32,40 @@ public class ExpenseController implements ExpenseApi {
 	@Override
 	@PostMapping("/add")
 	public ResponseEntity<ExpenseResponseDto> createExpense(
-			@Parameter(description = "user_id, category_id, amount, description, expenseDate")
-			@RequestBody ExpenseRequestDto expenseRequestDto) {
+		@Parameter(description = "user_id, category_id, amount, description, expenseDate")
+		@RequestBody ExpenseRequestDto expenseRequestDto) {
 		ExpenseResponseDto response = expenseService.createExpense(expenseRequestDto);
 		return ResponseEntity.ok(response);
 	}
 
 	@Override
 	@GetMapping("/{userId}")
-	public ResponseEntity<MonthlyExpenseCompactResponseDto> findExpensesForMonth(Pageable pageable,
-																				 @PathVariable @Param("userId") Long userId,
-																				 @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+	public ResponseEntity<MonthlyExpenseCompactResponseDto> findExpensesForMonth(
+		@PathVariable @Param("userId") Long userId,
+		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
 
-		return ResponseEntity.ok(expenseService.getMonthlyExpense(pageable, userId, date));
+		return ResponseEntity.ok(expenseService.getMonthlyExpense(userId, date));
 	}
 
 	@Override
 	@GetMapping("/{userId}/{expenseId}")
 	public ResponseEntity<ExpenseResponseDto> findExpense(@PathVariable @Param("userId") Long userId,
-														  @PathVariable @Param("expenseId") Long expenseId) {
+		@PathVariable @Param("expenseId") Long expenseId) {
 		return ResponseEntity.ok(expenseService.findExpenseResponseFromUserIdAndExpenseId(userId, expenseId));
 	}
 
 	@Override
 	@PostMapping("/{userId}")
 	public ResponseEntity<ExpenseResponseDto> updateExpense(@PathVariable @Param("userId") Long userId,
-															@RequestBody ExpenseUpdateRequestDto request) {
+		@RequestBody ExpenseUpdateRequestDto request) {
 		ExpenseResponseDto response = expenseService.updateExpense(userId, request);
 		return ResponseEntity.ok(response);
 	}
 
 	@DeleteMapping("/delete/{expenseId}")
 	public ResponseEntity<String> deleteExpense(
-			@Parameter(description = "expense_id")
-			@PathVariable Long expenseId) {
+		@Parameter(description = "expense_id")
+		@PathVariable Long expenseId) {
 		expenseService.deleteExpense(expenseId);
 		return ResponseEntity.ok("Successfully deleted expense!");
 	}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/CompactExpenseResponseDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/CompactExpenseResponseDto.java
@@ -1,9 +1,5 @@
 package com.bbteam.budgetbuddies.domain.expense.dto;
 
-import java.time.LocalDateTime;
-
-import com.fasterxml.jackson.annotation.JsonFormat;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,7 +15,4 @@ public class CompactExpenseResponseDto {
 	private String description;
 	private Long amount;
 	private Long categoryId;
-
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-	private LocalDateTime expenseDate;
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/MonthlyExpenseCompactResponseDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/MonthlyExpenseCompactResponseDto.java
@@ -2,6 +2,7 @@ package com.bbteam.budgetbuddies.domain.expense.dto;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class MonthlyExpenseCompactResponseDto {
 	private LocalDate expenseMonth;
-	private int currentPage;
-	private boolean hasNext;
-	private List<CompactExpenseResponseDto> expenseList;
+	private Long totalConsumptionAmount;
+
+	private Map<String, List<CompactExpenseResponseDto>> expenses;
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/repository/ExpenseRepository.java
@@ -3,8 +3,6 @@ package com.bbteam.budgetbuddies.domain.expense.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,6 +12,6 @@ import com.bbteam.budgetbuddies.domain.user.entity.User;
 
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 	@Query("SELECT e FROM Expense e WHERE e.user = :user AND e.expenseDate BETWEEN :startDate AND :endDate ORDER BY e.expenseDate DESC")
-	Slice<Expense> findAllByUserIdForPeriod(Pageable pageable, @Param("user") User user,
-											@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+	List<Expense> findAllByUserIdForPeriod(@Param("user") User user,
+		@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseService.java
@@ -2,8 +2,6 @@ package com.bbteam.budgetbuddies.domain.expense.service;
 
 import java.time.LocalDate;
 
-import org.springframework.data.domain.Pageable;
-
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseRequestDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseUpdateRequestDto;
@@ -12,7 +10,7 @@ import com.bbteam.budgetbuddies.domain.expense.dto.MonthlyExpenseCompactResponse
 public interface ExpenseService {
 	ExpenseResponseDto createExpense(ExpenseRequestDto expenseRequestDto);
 
-	MonthlyExpenseCompactResponseDto getMonthlyExpense(Pageable pageable, Long userId, LocalDate localDate);
+	MonthlyExpenseCompactResponseDto getMonthlyExpense(Long userId, LocalDate localDate);
 
 	ExpenseResponseDto findExpenseResponseFromUserIdAndExpenseId(Long userId, Long expenseId);
 

--- a/src/test/java/com/bbteam/budgetbuddies/domain/expense/repository/ExpenseRepositoryTest.java
+++ b/src/test/java/com/bbteam/budgetbuddies/domain/expense/repository/ExpenseRepositoryTest.java
@@ -11,9 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 
 import com.bbteam.budgetbuddies.domain.category.entity.Category;
 import com.bbteam.budgetbuddies.domain.category.repository.CategoryRepository;
@@ -42,17 +39,16 @@ class ExpenseRepositoryTest {
 		Category userCategory = categoryRepository.save(
 			Category.builder().name("유저 카테고리").user(user).isDefault(false).build());
 
-		LocalDate startDate = LocalDate.of(2024, 07, 01);
+		LocalDate startDate = LocalDate.of(2024, 7, 1);
 		LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
 
 		List<Expense> expected = setExpense(user, userCategory, startDate);
 
-		Pageable pageable = PageRequest.of(0, 5);
-
-		Slice<Expense> result = expenseRepository.findAllByUserIdForPeriod(pageable, user,
+		// when
+		List<Expense> result = expenseRepository.findAllByUserIdForPeriod(user,
 			startDate.atStartOfDay(), endDate.atStartOfDay());
 
-		assertThat(result.getContent()).usingRecursiveComparison().isEqualTo(expected);
+		assertThat(result).usingRecursiveComparison().isEqualTo(expected);
 	}
 
 	private List<Expense> setExpense(User user, Category userCategory, LocalDate startDate) {


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
월별 소비 조회시 사용자의 총 소비 금액과 d일 N요일로 소비를 묶어서 반환

## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
