### PR TITLE
[v6.1] 월별 소비 조회 총 소비 금액 및 요일별로 반환

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/bbteam/budgetbuddies/apiPayload/code/status/ErrorStatus.java
@@ -12,6 +12,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
 
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버에러"),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청"),
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMENT4001", "해당 댓글이 없습니다.") ,
     PAGE_LOWER_ZERO(HttpStatus.BAD_REQUEST, "PAGE4001", "요청된 페이지가 0보다 작습니다.");

--- a/src/main/java/com/bbteam/budgetbuddies/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/comment/controller/CommentController.java
@@ -6,6 +6,7 @@ import com.bbteam.budgetbuddies.domain.comment.dto.CommentResponseDto;
 import com.bbteam.budgetbuddies.domain.comment.service.CommentService;
 import com.bbteam.budgetbuddies.domain.comment.validation.ExistComment;
 import com.bbteam.budgetbuddies.domain.user.validation.ExistUser;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -75,27 +76,27 @@ public class CommentController implements CommentControllerApi {
     }
 
     @GetMapping("/supports/comments/getOne/{commentId}")
-    public ApiResponse<CommentResponseDto.SupportInfoCommentResponseDto> findSupportOne(@PathVariable("commentId")Long commentId) {
+    public ApiResponse<CommentResponseDto.SupportInfoCommentResponseDto> findSupportOne(@PathVariable("commentId") @ExistComment Long commentId) {
         CommentResponseDto.SupportInfoCommentResponseDto result = supportCommentService.findCommentOne(commentId);
         return ApiResponse.onSuccess(result);
     }
 
     @PutMapping("/supports/comments/modify")
     public ApiResponse<CommentResponseDto.SupportInfoCommentResponseDto> modifySupportOne(
-            @RequestBody CommentRequestDto.CommentModifyRequestDto dto) {
+            @RequestBody @Valid CommentRequestDto.CommentModifyRequestDto dto) {
         CommentResponseDto.SupportInfoCommentResponseDto result = supportCommentService.modifyComment(dto);
         return ApiResponse.onSuccess(result);
     }
 
     @GetMapping("/discounts/comments/getOne/{commentId}")
-    public ApiResponse<CommentResponseDto.DiscountInfoCommentResponseDto> findDiscountOne(@PathVariable("commentId")Long commentId) {
+    public ApiResponse<CommentResponseDto.DiscountInfoCommentResponseDto> findDiscountOne(@PathVariable("commentId") @ExistComment Long commentId) {
         CommentResponseDto.DiscountInfoCommentResponseDto result = discountCommentService.findCommentOne(commentId);
         return ApiResponse.onSuccess(result);
     }
 
     @PutMapping("/discounts/comments/modify")
     public ApiResponse<CommentResponseDto.DiscountInfoCommentResponseDto> modifyDiscountOne(
-            @RequestBody CommentRequestDto.CommentModifyRequestDto dto) {
+            @RequestBody @Valid CommentRequestDto.CommentModifyRequestDto dto) {
         CommentResponseDto.DiscountInfoCommentResponseDto result = discountCommentService.modifyComment(dto);
         return ApiResponse.onSuccess(result);
     }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/comment/controller/CommentControllerApi.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/comment/controller/CommentControllerApi.java
@@ -10,11 +10,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -90,7 +90,7 @@ public interface CommentControllerApi {
     @Parameters({
             @Parameter(name = "commentId", description = "조회할 댓글 id 입니다. pathVariable")
     })
-    ApiResponse<CommentResponseDto.SupportInfoCommentResponseDto> findSupportOne(@RequestParam("commentId")Long commentId);
+    ApiResponse<CommentResponseDto.SupportInfoCommentResponseDto> findSupportOne(@PathVariable("commentId") @ExistComment Long commentId);
 
     @Operation(summary = "[User] SupportInfo의 댓글 변경 API", description = "특정 댓글을 변경하는 API입니다.")
     @ApiResponses({
@@ -102,7 +102,7 @@ public interface CommentControllerApi {
 
     })
     ApiResponse<CommentResponseDto.SupportInfoCommentResponseDto> modifySupportOne(
-            @RequestBody CommentRequestDto.CommentModifyRequestDto dto);
+            @RequestBody @Valid CommentRequestDto.CommentModifyRequestDto dto);
 
 
     @Operation(summary = "[User] DiscountInfo의 특정 댓글 요청 API", description = "특정 댓글을 요청하는 API입니다.")
@@ -112,7 +112,7 @@ public interface CommentControllerApi {
     @Parameters({
             @Parameter(name = "commentId", description = "조회할 댓글 id 입니다. pathVariable")
     })
-    ApiResponse<CommentResponseDto.DiscountInfoCommentResponseDto> findDiscountOne(@RequestParam("commentId")Long commentId);
+    ApiResponse<CommentResponseDto.DiscountInfoCommentResponseDto> findDiscountOne(@PathVariable("commentId") @ExistComment Long commentId);
 
     @Operation(summary = "[User] DiscountInfo의 댓글 변경 API", description = "특정 댓글을 변경하는 API입니다.")
     @ApiResponses({
@@ -124,6 +124,6 @@ public interface CommentControllerApi {
 
     })
     ApiResponse<CommentResponseDto.DiscountInfoCommentResponseDto> modifyDiscountOne(
-            @RequestBody CommentRequestDto.CommentModifyRequestDto dto);
+            @RequestBody @Valid CommentRequestDto.CommentModifyRequestDto dto);
 
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/comment/dto/CommentRequestDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/comment/dto/CommentRequestDto.java
@@ -1,5 +1,6 @@
 package com.bbteam.budgetbuddies.domain.comment.dto;
 
+import com.bbteam.budgetbuddies.domain.comment.validation.ExistComment;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -23,6 +24,8 @@ public class CommentRequestDto {
     @Builder
     public static class CommentModifyRequestDto {
         private String content;
+
+        @ExistComment
         private Long commentId;
     }
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/ExpenseApi.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/ExpenseApi.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseRequestDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseUpdateRequestDto;
-import com.bbteam.budgetbuddies.domain.expense.dto.MonthlyExpenseCompactResponseDto;
+import com.bbteam.budgetbuddies.domain.expense.dto.MonthlyExpenseResponseDto;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -42,7 +42,7 @@ public interface ExpenseApi {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
 		@ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
 		@ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
-	ResponseEntity<MonthlyExpenseCompactResponseDto> findExpensesForMonth(
+	ResponseEntity<MonthlyExpenseResponseDto> findExpensesForMonth(
 		@PathVariable @Param("userId") Long userId,
 		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date);
 

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/controller/ExpenseController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseRequestDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseUpdateRequestDto;
-import com.bbteam.budgetbuddies.domain.expense.dto.MonthlyExpenseCompactResponseDto;
+import com.bbteam.budgetbuddies.domain.expense.dto.MonthlyExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.service.ExpenseService;
 
 import io.swagger.v3.oas.annotations.Parameter;
@@ -40,7 +40,7 @@ public class ExpenseController implements ExpenseApi {
 
 	@Override
 	@GetMapping("/{userId}")
-	public ResponseEntity<MonthlyExpenseCompactResponseDto> findExpensesForMonth(
+	public ResponseEntity<MonthlyExpenseResponseDto> findExpensesForMonth(
 		@PathVariable @Param("userId") Long userId,
 		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
 

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/DailyExpenseResponseDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/DailyExpenseResponseDto.java
@@ -1,8 +1,6 @@
 package com.bbteam.budgetbuddies.domain.expense.dto;
 
-import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -10,13 +8,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Builder
-public class MonthlyExpenseCompactResponseDto {
-	private LocalDate expenseMonth;
-	private Long totalConsumptionAmount;
-
-	private Map<String, List<CompactExpenseResponseDto>> expenses;
+@Getter
+public class DailyExpenseResponseDto {
+	private String daysOfMonth;
+	private String daysOfTheWeek;
+	private List<CompactExpenseResponseDto> expenses;
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/DailyExpenseResponseDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/DailyExpenseResponseDto.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Getter
 public class DailyExpenseResponseDto {
-	private String daysOfMonth;
+	private Integer daysOfMonth;
 	private String daysOfTheWeek;
 	private List<CompactExpenseResponseDto> expenses;
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/MonthlyExpenseResponseDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/dto/MonthlyExpenseResponseDto.java
@@ -1,0 +1,21 @@
+package com.bbteam.budgetbuddies.domain.expense.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Builder
+public class MonthlyExpenseResponseDto {
+	private LocalDate expenseMonth;
+	private Long totalConsumptionAmount;
+
+	private List<DailyExpenseResponseDto> dailyExpenses;
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseService.java
@@ -5,12 +5,12 @@ import java.time.LocalDate;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseRequestDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseUpdateRequestDto;
-import com.bbteam.budgetbuddies.domain.expense.dto.MonthlyExpenseCompactResponseDto;
+import com.bbteam.budgetbuddies.domain.expense.dto.MonthlyExpenseResponseDto;
 
 public interface ExpenseService {
 	ExpenseResponseDto createExpense(Long userId, ExpenseRequestDto expenseRequestDto);
 
-	MonthlyExpenseCompactResponseDto getMonthlyExpense(Long userId, LocalDate localDate);
+	MonthlyExpenseResponseDto getMonthlyExpense(Long userId, LocalDate localDate);
 
 	ExpenseResponseDto findExpenseResponseFromUserIdAndExpenseId(Long userId, Long expenseId);
 

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseServiceImpl.java
@@ -14,7 +14,7 @@ import com.bbteam.budgetbuddies.domain.expense.converter.ExpenseConverter;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseRequestDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseUpdateRequestDto;
-import com.bbteam.budgetbuddies.domain.expense.dto.MonthlyExpenseCompactResponseDto;
+import com.bbteam.budgetbuddies.domain.expense.dto.MonthlyExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.entity.Expense;
 import com.bbteam.budgetbuddies.domain.expense.repository.ExpenseRepository;
 import com.bbteam.budgetbuddies.domain.user.entity.User;
@@ -92,7 +92,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public MonthlyExpenseCompactResponseDto getMonthlyExpense(Long userId, LocalDate localDate) {
+	public MonthlyExpenseResponseDto getMonthlyExpense(Long userId, LocalDate localDate) {
 		LocalDate startOfMonth = localDate.withDayOfMonth(1);
 		LocalDate endOfMonth = localDate.withDayOfMonth(startOfMonth.lengthOfMonth());
 
@@ -101,7 +101,7 @@ public class ExpenseServiceImpl implements ExpenseService {
 		List<Expense> expenseSlice = expenseRepository.findAllByUserIdForPeriod(user,
 			startOfMonth.atStartOfDay(), endOfMonth.atStartOfDay());
 
-		return expenseConverter.toMonthlyExpenseCompactResponseDto(expenseSlice, startOfMonth);
+		return expenseConverter.toMonthlyExpenseResponseDto(expenseSlice, startOfMonth);
 	}
 
 	@Override

--- a/src/test/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseServiceImplTest.java
+++ b/src/test/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseServiceImplTest.java
@@ -25,7 +25,7 @@ import com.bbteam.budgetbuddies.domain.category.repository.CategoryRepository;
 import com.bbteam.budgetbuddies.domain.expense.converter.ExpenseConverter;
 import com.bbteam.budgetbuddies.domain.expense.dto.CompactExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
-import com.bbteam.budgetbuddies.domain.expense.dto.MonthlyExpenseCompactResponseDto;
+import com.bbteam.budgetbuddies.domain.expense.dto.MonthlyExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.entity.Expense;
 import com.bbteam.budgetbuddies.domain.expense.repository.ExpenseRepository;
 import com.bbteam.budgetbuddies.domain.user.entity.User;
@@ -69,8 +69,8 @@ class ExpenseServiceImplTest {
 		given(expenseRepository.findAllByUserIdForPeriod(any(User.class), any(LocalDateTime.class),
 			any(LocalDateTime.class))).willReturn(expenses);
 
-		MonthlyExpenseCompactResponseDto expected =
-			MonthlyExpenseCompactResponseDto.builder()
+		MonthlyExpenseResponseDto expected =
+			MonthlyExpenseResponseDto.builder()
 				.expenseMonth(LocalDate.of(2024, 07, 01))
 				.totalConsumptionAmount(300_000L)
 				.expenses(Map.of(
@@ -89,7 +89,7 @@ class ExpenseServiceImplTest {
 				.build();
 
 		// when
-		MonthlyExpenseCompactResponseDto result = expenseService.getMonthlyExpense(user.getId(), requestMonth);
+		MonthlyExpenseResponseDto result = expenseService.getMonthlyExpense(user.getId(), requestMonth);
 
 		// then
 		assertThat(result).usingRecursiveComparison().isEqualTo(expected);

--- a/src/test/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseServiceImplTest.java
+++ b/src/test/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseServiceImplTest.java
@@ -7,7 +7,6 @@ import static org.mockito.BDDMockito.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +23,7 @@ import com.bbteam.budgetbuddies.domain.category.entity.Category;
 import com.bbteam.budgetbuddies.domain.category.repository.CategoryRepository;
 import com.bbteam.budgetbuddies.domain.expense.converter.ExpenseConverter;
 import com.bbteam.budgetbuddies.domain.expense.dto.CompactExpenseResponseDto;
+import com.bbteam.budgetbuddies.domain.expense.dto.DailyExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.ExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.dto.MonthlyExpenseResponseDto;
 import com.bbteam.budgetbuddies.domain.expense.entity.Expense;
@@ -54,7 +54,7 @@ class ExpenseServiceImplTest {
 	}
 
 	@Test
-	@DisplayName("월별 소비 조회 소비를 d일 N요일로 묶어서 반환")
+	@DisplayName("월별 소비 조회 소비를 DailyExpenseResponseDto로 반환")
 	void getMonthlyExpense_Success() {
 		// given
 		given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
@@ -69,24 +69,29 @@ class ExpenseServiceImplTest {
 		given(expenseRepository.findAllByUserIdForPeriod(any(User.class), any(LocalDateTime.class),
 			any(LocalDateTime.class))).willReturn(expenses);
 
-		MonthlyExpenseResponseDto expected =
-			MonthlyExpenseResponseDto.builder()
-				.expenseMonth(LocalDate.of(2024, 07, 01))
-				.totalConsumptionAmount(300_000L)
-				.expenses(Map.of(
-					"2일 화요일", List.of(CompactExpenseResponseDto.builder()
-						.amount(200_000L)
-						.description("User 소비")
-						.expenseId(-2L)
-						.categoryId(userCategory.getId())
-						.build()),
-					"1일 월요일", List.of(CompactExpenseResponseDto.builder()
-						.amount(100_000L)
-						.description("User 소비")
-						.expenseId(-1L)
-						.categoryId(userCategory.getId())
-						.build())))
-				.build();
+		MonthlyExpenseResponseDto expected = MonthlyExpenseResponseDto.builder()
+			.expenseMonth(LocalDate.of(2024, 07, 01))
+			.totalConsumptionAmount(300_000L)
+			.dailyExpenses(List.of(DailyExpenseResponseDto.builder()
+				.daysOfMonth(2)
+				.daysOfTheWeek("화요일")
+				.expenses(List.of(CompactExpenseResponseDto.builder()
+					.amount(200_000L)
+					.description("User 소비")
+					.expenseId(-2L)
+					.categoryId(userCategory.getId())
+					.build()))
+				.build(), DailyExpenseResponseDto.builder()
+				.daysOfMonth(1)
+				.daysOfTheWeek("월요일")
+				.expenses(List.of(CompactExpenseResponseDto.builder()
+					.amount(100_000L)
+					.description("User 소비")
+					.expenseId(-1L)
+					.categoryId(userCategory.getId())
+					.build()))
+				.build()))
+			.build();
 
 		// when
 		MonthlyExpenseResponseDto result = expenseService.getMonthlyExpense(user.getId(), requestMonth);


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
> description
![image](https://github.com/user-attachments/assets/bcf61e90-274a-44e1-a89b-26f5f15bc745)
월별 소비 조회 부분에서 전체 소비금액 구현 및 일별 반환

## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
