### PR TITLE
[fix] 할인정보 및 지원정보 수정/삭제 버그 수정

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/controller/DiscountInfoApi.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/controller/DiscountInfoApi.java
@@ -3,6 +3,7 @@ package com.bbteam.budgetbuddies.domain.discountinfo.controller;
 import com.bbteam.budgetbuddies.apiPayload.ApiResponse;
 import com.bbteam.budgetbuddies.domain.discountinfo.dto.DiscountRequest;
 import com.bbteam.budgetbuddies.domain.discountinfo.dto.DiscountResponseDto;
+import com.bbteam.budgetbuddies.domain.user.validation.ExistUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -60,11 +61,11 @@ public interface DiscountInfoApi {
         @Parameter(name = "discountInfoId", description = "좋아요를 누를 할인정보의 id입니다."),
     })
     ApiResponse<DiscountResponseDto> likeDiscountInfo(
-        @RequestParam Long userId,
+        @RequestParam @ExistUser Long userId,
         @PathVariable Long discountInfoId
     );
 
-    @Operation(summary = "[ADMIN] 특정 할인정보 수정하기 API", description = "특정 할인정보를 수정하는 API이며, 일단은 사용자 ID를 입력하여 사용합니다. (추후 토큰으로 검증)")
+    @Operation(summary = "[ADMIN] 특정 할인정보 수정하기 API", description = "특정 할인정보를 수정하는 API입니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
 //        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
@@ -72,15 +73,12 @@ public interface DiscountInfoApi {
 //        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameters({
-        @Parameter(name = "userId", description = "수정할 사용자의 id입니다."),
-//        @Parameter(name = "discountRequestDto", description = "수정할 할인 정보의 전체 내용입니다."),
     })
     ApiResponse<DiscountResponseDto> updateDiscountInfo(
-        @RequestParam Long userId,
         @RequestBody DiscountRequest.UpdateDiscountDto discountRequestDto
     );
 
-    @Operation(summary = "[ADMIN] 특정 할인정보 삭제하기 API", description = "특정 할인정보를 삭제하는 API이며, 일단은 사용자 ID를 입력하여 사용합니다. (추후 토큰으로 검증)")
+    @Operation(summary = "[ADMIN] 특정 할인정보 삭제하기 API", description = "ID를 통해 특정 할인정보를 삭제하는 API입니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
 //        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
@@ -88,15 +86,13 @@ public interface DiscountInfoApi {
 //        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameters({
-        @Parameter(name = "userId", description = "삭제할 사용자의 id입니다."),
         @Parameter(name = "discountInfoId", description = "삭제할 할인 정보의 id입니다."),
     })
     ApiResponse<String> deleteDiscountInfo(
-        @RequestParam Long userId,
         @PathVariable Long discountInfoId
     );
 
-    @Operation(summary = "[ADMIN] 특정 할인정보 가져오기 API", description = "ID를 통해 특정 할인정보를 가져오는 API이며, 일단은 사용자 ID를 입력하여 사용합니다. (추후 토큰으로 검증)")
+    @Operation(summary = "[ADMIN] 특정 할인정보 가져오기 API", description = "ID를 통해 특정 할인정보를 가져오는 API입니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
 //        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
@@ -104,11 +100,9 @@ public interface DiscountInfoApi {
 //        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameters({
-        @Parameter(name = "userId", description = "조회할 사용자의 id입니다."),
         @Parameter(name = "discountInfoId", description = "조회할 할인 정보의 id입니다."),
     })
     ApiResponse<DiscountResponseDto> getDiscountInfo(
-        @RequestParam Long userId,
         @PathVariable Long discountInfoId
     );
 

--- a/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/controller/DiscountInfoController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/controller/DiscountInfoController.java
@@ -53,10 +53,9 @@ public class DiscountInfoController implements DiscountInfoApi {
     @Override
     @PutMapping("")
     public ApiResponse<DiscountResponseDto> updateDiscountInfo(
-        @RequestParam @ExistUser Long userId,
         @RequestBody DiscountRequest.UpdateDiscountDto discountRequestDto
     ) {
-        DiscountResponseDto discountResponseDto = discountInfoService.updateDiscountInfo(userId, discountRequestDto);
+        DiscountResponseDto discountResponseDto = discountInfoService.updateDiscountInfo(discountRequestDto);
 
         return ApiResponse.onSuccess(discountResponseDto);
     }
@@ -64,10 +63,9 @@ public class DiscountInfoController implements DiscountInfoApi {
     @Override
     @DeleteMapping("/{discountInfoId}")
     public ApiResponse<String> deleteDiscountInfo(
-        @RequestParam @ExistUser Long userId,
         @PathVariable Long discountInfoId
     ) {
-        String message = discountInfoService.deleteDiscountInfo(userId, discountInfoId);
+        String message = discountInfoService.deleteDiscountInfo(discountInfoId);
 
         return ApiResponse.onSuccess(message);
     }
@@ -76,10 +74,9 @@ public class DiscountInfoController implements DiscountInfoApi {
     @Override
     @GetMapping("/{discountInfoId}")
     public ApiResponse<DiscountResponseDto> getDiscountInfo(
-        @RequestParam @ExistUser Long userId,
         @PathVariable Long discountInfoId
     ) {
-        DiscountResponseDto discountResponseDto = discountInfoService.getDiscountInfoById(userId, discountInfoId);
+        DiscountResponseDto discountResponseDto = discountInfoService.getDiscountInfoById(discountInfoId);
 
         return ApiResponse.onSuccess(discountResponseDto);
     }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/service/DiscountInfoService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/service/DiscountInfoService.java
@@ -16,10 +16,10 @@ public interface DiscountInfoService {
 
     DiscountResponseDto toggleLike(Long userId, Long discountInfoId);
 
-    DiscountResponseDto updateDiscountInfo(Long userId, DiscountRequest.UpdateDiscountDto discountRequestDto);
+    DiscountResponseDto updateDiscountInfo(DiscountRequest.UpdateDiscountDto discountRequestDto);
 
-    String deleteDiscountInfo(Long userId, Long discountInfoId);
+    String deleteDiscountInfo(Long discountInfoId);
 
-    DiscountResponseDto getDiscountInfoById(Long userId, Long discountInfoId);
+    DiscountResponseDto getDiscountInfoById(Long discountInfoId);
 
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/service/DiscountInfoServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/service/DiscountInfoServiceImpl.java
@@ -117,17 +117,14 @@ public class DiscountInfoServiceImpl implements DiscountInfoService {
 
     @Transactional
     @Override
-    public DiscountResponseDto updateDiscountInfo(Long userId, DiscountRequest.UpdateDiscountDto discountRequestDto) {
+    public DiscountResponseDto updateDiscountInfo(DiscountRequest.UpdateDiscountDto discountRequestDto) {
         /**
-         * 1. 사용자 조회 -> 없으면 에러
-         * 2. 할인정보 조회 -> 없으면 에러
-         * 3. 변경사항 업데이트
-         * 4. 변경사항 저장
-         * 5. Entity -> ResponseDto로 변환 후 리턴
+         * 1. 할인정보 조회 -> 없으면 에러
+         * 2. 변경사항 업데이트
+         * 3. 변경사항 저장
+         * 4. Entity -> ResponseDto로 변환 후 리턴
          */
 
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         DiscountInfo discountInfo = discountInfoRepository.findById(discountRequestDto.getId())
             .orElseThrow(() -> new IllegalArgumentException("DiscountInfo not found"));
@@ -141,16 +138,12 @@ public class DiscountInfoServiceImpl implements DiscountInfoService {
 
     @Transactional
     @Override
-    public String deleteDiscountInfo(Long userId, Long discountInfoId) {
+    public String deleteDiscountInfo(Long discountInfoId) {
         /**
-         * 1. 사용자 조회 -> 없으면 에러
-         * 2. 할인정보 조회 -> 없으면 에러
-         * 3. Entity 삭제
-         * 4. 성공여부 반환
+         * 1. 할인정보 조회 -> 없으면 에러
+         * 2. Entity 삭제
+         * 3. 성공여부 반환
          */
-
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         DiscountInfo discountInfo = discountInfoRepository.findById(discountInfoId)
             .orElseThrow(() -> new IllegalArgumentException("DiscountInfo not found"));
@@ -163,16 +156,12 @@ public class DiscountInfoServiceImpl implements DiscountInfoService {
 
     @Transactional
     @Override
-    public DiscountResponseDto getDiscountInfoById(Long userId, Long discountInfoId) {
+    public DiscountResponseDto getDiscountInfoById(Long discountInfoId) {
         /**
-         * 1. 사용자 조회 -> 없으면 에러
-         * 2. 할인정보 조회 -> 없으면 에러
-         * 3. Entity 조회
-         * 4. Entity -> ResponseDto로 변환 후 리턴
+         * 1. 할인정보 조회 -> 없으면 에러
+         * 2. Entity 조회
+         * 3. Entity -> ResponseDto로 변환 후 리턴
          */
-
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         DiscountInfo discountInfo = discountInfoRepository.findById(discountInfoId)
             .orElseThrow(() -> new IllegalArgumentException("DiscountInfo not found"));

--- a/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/controller/SupportInfoApi.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/controller/SupportInfoApi.java
@@ -3,6 +3,7 @@ package com.bbteam.budgetbuddies.domain.supportinfo.controller;
 import com.bbteam.budgetbuddies.apiPayload.ApiResponse;
 import com.bbteam.budgetbuddies.domain.supportinfo.dto.SupportRequest;
 import com.bbteam.budgetbuddies.domain.supportinfo.dto.SupportResponseDto;
+import com.bbteam.budgetbuddies.domain.user.validation.ExistUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -57,11 +58,11 @@ public interface SupportInfoApi {
         @Parameter(name = "supportInfoId", description = "좋아요를 누를 지원정보의 id입니다."),
     })
     ApiResponse<SupportResponseDto> likeSupportInfo(
-        @RequestParam Long userId,
+        @RequestParam @ExistUser Long userId,
         @PathVariable Long supportInfoId
     );
 
-    @Operation(summary = "[ADMIN] 특정 지원정보 수정하기 API", description = "특정 지원정보를 수정하는 API이며, 일단은 사용자 ID를 입력하여 사용합니다. (추후 토큰으로 검증)")
+    @Operation(summary = "[ADMIN] 특정 지원정보 수정하기 API", description = "ID를 통해 특정 지원정보를 수정하는 API입니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
 //        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
@@ -69,14 +70,12 @@ public interface SupportInfoApi {
 //        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameters({
-        @Parameter(name = "userId", description = "수정할 사용자의 id입니다."),
     })
     ApiResponse<SupportResponseDto> updateSupportInfo(
-        @RequestParam Long userId,
         @RequestBody SupportRequest.UpdateSupportDto supportRequestDto
     );
 
-    @Operation(summary = "[ADMIN] 특정 지원정보 삭제하기 API", description = "특정 지원정보를 삭제하는 API이며, 일단은 사용자 ID를 입력하여 사용합니다. (추후 토큰으로 검증)")
+    @Operation(summary = "[ADMIN] 특정 지원정보 삭제하기 API", description = "ID를 통해 특정 지원정보를 삭제하는 API입니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
 //        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
@@ -84,15 +83,13 @@ public interface SupportInfoApi {
 //        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameters({
-        @Parameter(name = "userId", description = "삭제할 사용자의 id입니다."),
         @Parameter(name = "supportInfoId", description = "삭제할 지원 정보의 id입니다."),
     })
     ApiResponse<String> deleteSupportInfo(
-        @RequestParam Long userId,
         @PathVariable Long supportInfoId
     );
 
-    @Operation(summary = "[ADMIN] 특정 지원정보 가져오기 API", description = "ID를 통해 특정 지원정보를 가져오는 API이며, 일단은 사용자 ID를 입력하여 사용합니다. (추후 토큰으로 검증)")
+    @Operation(summary = "[ADMIN] 특정 지원정보 가져오기 API", description = "ID를 통해 특정 지원정보를 가져오는 API입니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
 //        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
@@ -100,11 +97,9 @@ public interface SupportInfoApi {
 //        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameters({
-        @Parameter(name = "userId", description = "조회할 사용자의 id입니다."),
         @Parameter(name = "supportInfoId", description = "조회할 지원 정보의 id입니다."),
     })
     ApiResponse<SupportResponseDto> getSupportInfo(
-        @RequestParam Long userId,
         @PathVariable Long supportInfoId
     );
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/controller/SupportInfoController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/controller/SupportInfoController.java
@@ -53,10 +53,9 @@ public class SupportInfoController implements SupportInfoApi {
     @Override
     @PutMapping("")
     public ApiResponse<SupportResponseDto> updateSupportInfo(
-        @RequestParam @ExistUser Long userId,
         @RequestBody SupportRequest.UpdateSupportDto supportRequestDto
     ) {
-        SupportResponseDto supportResponseDto = supportInfoService.updateSupportInfo(userId, supportRequestDto);
+        SupportResponseDto supportResponseDto = supportInfoService.updateSupportInfo(supportRequestDto);
 
         return ApiResponse.onSuccess(supportResponseDto);
     }
@@ -64,10 +63,9 @@ public class SupportInfoController implements SupportInfoApi {
     @Override
     @DeleteMapping("/{supportInfoId}")
     public ApiResponse<String> deleteSupportInfo(
-        @RequestParam @ExistUser Long userId,
         @PathVariable Long supportInfoId
     ) {
-        String message = supportInfoService.deleteSupportInfo(userId, supportInfoId);
+        String message = supportInfoService.deleteSupportInfo(supportInfoId);
 
         return ApiResponse.onSuccess(message);
     }
@@ -75,10 +73,9 @@ public class SupportInfoController implements SupportInfoApi {
     @Override
     @GetMapping("/{supportInfoId}")
     public ApiResponse<SupportResponseDto> getSupportInfo(
-        @RequestParam @ExistUser Long userId,
         @PathVariable Long supportInfoId
     ) {
-        SupportResponseDto supportResponseDto = supportInfoService.getSupportInfoById(userId, supportInfoId);
+        SupportResponseDto supportResponseDto = supportInfoService.getSupportInfoById(supportInfoId);
 
         return ApiResponse.onSuccess(supportResponseDto);
     }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/service/SupportInfoService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/service/SupportInfoService.java
@@ -16,10 +16,10 @@ public interface SupportInfoService {
 
     SupportResponseDto toggleLike(Long userId, Long supportInfoId);
 
-    SupportResponseDto updateSupportInfo(Long userId, SupportRequest.UpdateSupportDto supportRequestDto);
+    SupportResponseDto updateSupportInfo(SupportRequest.UpdateSupportDto supportRequestDto);
 
-    String deleteSupportInfo(Long userId, Long supportInfoId);
+    String deleteSupportInfo(Long supportInfoId);
 
-    SupportResponseDto getSupportInfoById(Long userId, Long supportInfoId);
+    SupportResponseDto getSupportInfoById(Long supportInfoId);
 
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/service/SupportInfoServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/service/SupportInfoServiceImpl.java
@@ -117,17 +117,13 @@ public class SupportInfoServiceImpl implements SupportInfoService {
 
     @Transactional
     @Override
-    public SupportResponseDto updateSupportInfo(Long userId, SupportRequest.UpdateSupportDto supportRequestDto) {
+    public SupportResponseDto updateSupportInfo(SupportRequest.UpdateSupportDto supportRequestDto) {
         /**
-         * 1. 사용자 조회 -> 없으면 에러
-         * 2. 지원정보 조회 -> 없으면 에러
-         * 3. 변경사항 업데이트
-         * 4. 변경사항 저장
-         * 5. Entity -> ResponseDto로 변환 후 리턴
+         * 1. 지원정보 조회 -> 없으면 에러
+         * 2. 변경사항 업데이트
+         * 3. 변경사항 저장
+         * 4. Entity -> ResponseDto로 변환 후 리턴
          */
-
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         SupportInfo supportInfo = supportInfoRepository.findById(supportRequestDto.getId())
             .orElseThrow(() -> new IllegalArgumentException("SupportInfo not found"));
@@ -141,16 +137,12 @@ public class SupportInfoServiceImpl implements SupportInfoService {
 
     @Transactional
     @Override
-    public String deleteSupportInfo(Long userId, Long supportInfoId) {
+    public String deleteSupportInfo(Long supportInfoId) {
         /**
-         * 1. 사용자 조회 -> 없으면 에러
-         * 2. 지원정보 조회 -> 없으면 에러
-         * 3. Entity 삭제
-         * 4. 성공여부 반환
+         * 1. 지원정보 조회 -> 없으면 에러
+         * 2. Entity 삭제
+         * 3. 성공여부 반환
          */
-
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         SupportInfo supportInfo = supportInfoRepository.findById(supportInfoId)
             .orElseThrow(() -> new IllegalArgumentException("SupportInfo not found"));
@@ -163,16 +155,12 @@ public class SupportInfoServiceImpl implements SupportInfoService {
 
     @Transactional
     @Override
-    public SupportResponseDto getSupportInfoById(Long userId, Long supportInfoId) {
+    public SupportResponseDto getSupportInfoById(Long supportInfoId) {
         /**
-         * 1. 사용자 조회 -> 없으면 에러
-         * 2. 지원정보 조회 -> 없으면 에러
-         * 3. Entity 조회
-         * 4. Entity -> ResponseDto로 변환 후 리턴
+         * 1. 지원정보 조회 -> 없으면 에러
+         * 2. Entity 조회
+         * 3. Entity -> ResponseDto로 변환 후 리턴
          */
-
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         SupportInfo supportInfo = supportInfoRepository.findById(supportInfoId)
             .orElseThrow(() -> new IllegalArgumentException("SupportInfo not found"));


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#148 

할인정보 지원정보 수정 및 삭제 API 오류 수정

> 1. 기존에 할인정보 및 지원정보를 수정하거나 삭제할 때 User ID를 넘겨받도록 되어 있었음.
> -> 해당 부분을 User ID를 넘겨받지 않도록 설정
> -> 할인정보와 지원정보를 삭제할 때 굳이 유저 아이디를 받을 필요가 없음. (추후에는 관리자만 인증/인가를 통해 구현)
> 2. 인터페이스와 구현체 함수 원형이 일치하지 않은 부분을 통일 시켰음.
> -> 인터페이스 메소드에 @ExistUser 어노테이션 누락된 부분 추가



## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
