### PR TITLE
[fix] SecurityConfig csrf 설정 비활성화 (HOTFIX)

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/global/config/SecurityConfig.java
+++ b/src/main/java/com/bbteam/budgetbuddies/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
@@ -29,6 +30,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+            .csrf(AbstractHttpConfigurer::disable) // csrf 설정 비활성화
             .authorizeHttpRequests(authorizeRequests ->
                 authorizeRequests
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").hasRole("ADMIN")


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#153 

기본적으로 REST API만 사용하는 서비스는 csrf 설정을 비활성화 한다고 합니다.

csrf는 사용자의 세션을 사용자의 의도와는 무관하게 악의적으로 사용되는 것을 말합니다. 
보통, 사용자의 세션에 저장된 값을 다른 웹사이트에서 동일한 API를 호출할 때 발생합니다.

Spring Security는 추가 설정을 해주지 않으면 기본적으로 csrf 설정을 활성화합니다.
**이를 비활성화하여 스웨거나 앱 등의 클라이언트에서 POST, PUT, DELETE 요청을 보낼 수 있도록 설정합니다.**

## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
