### PR TITLE
[v11] 가계부 소비, 카테고리 삭제 관련 버그 수정

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/consumptiongoal/service/ConsumptionGoalService.java
@@ -20,17 +20,17 @@ import com.bbteam.budgetbuddies.domain.user.entity.User;
 public interface ConsumptionGoalService {
 
 	List<TopGoalCategoryResponseDto> getTopConsumptionGoalCategories(Long userId, int peerAgeStart, int peerAgeEnd,
-		String peerGender);
+																	 String peerGender);
 
 	List<AllConsumptionCategoryResponseDto> getAllConsumptionGoalCategories(Long userId, int peerAgeS, int peerAgeE,
-		String peerG);
+																			String peerG);
 
 	ConsumptionGoalResponseListDto findUserConsumptionGoalList(Long userId, LocalDate date);
 
 	PeerInfoResponseDto getPeerInfo(Long userId, int peerAgeStart, int peerAgeEnd, String peerGender);
 
 	ConsumptionGoalResponseListDto updateConsumptionGoals(Long userId,
-		ConsumptionGoalListRequestDto consumptionGoalListRequestDto);
+														  ConsumptionGoalListRequestDto consumptionGoalListRequestDto);
 
 	ConsumptionAnalysisResponseDto getTopCategoryAndConsumptionAmount(Long userId);
 
@@ -41,8 +41,10 @@ public interface ConsumptionGoalService {
 	void decreaseConsumeAmount(Long userId, Long categoryId, Long amount, LocalDate expenseDate);
 
 	List<TopCategoryConsumptionDto> getTopConsumptionCategories(Long userId, int peerAgeStart, int peerAgeEnd,
-		String peerGender);
+																String peerGender);
 
 	List<AllConsumptionCategoryResponseDto> getAllConsumptionCategories(Long userId, int peerAgeS, int peerAgeE,
-		String peerG);
+																		String peerG);
+
+	void updateOrCreateDeletedConsumptionGoal(Long userId, Long categoryId, LocalDate goalMonth, Long amount);
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/repository/ExpenseRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,4 +19,8 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 	List<Expense> findByCategoryIdAndUserIdAndExpenseDateBetweenAndDeletedFalse(Long categoryId, Long userId, LocalDateTime startDate, LocalDateTime endDate);
 
 	List<Expense> findByCategoryIdAndUserIdAndDeletedFalse(Long categoryId, Long userId);
+
+	@Modifying
+	@Query("UPDATE Expense e SET e.deleted = TRUE WHERE e.id = :expenseId")
+	void softDeleteById(@Param("expenseId") Long expenseId);
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/repository/ExpenseRepository.java
@@ -15,5 +15,7 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 	List<Expense> findAllByUserIdForPeriod(@Param("user") User user, @Param("startDate") LocalDateTime startDate,
 		@Param("endDate") LocalDateTime endDate);
 
-	@Query("SELECT e FROM Expense e WHERE e.category.id = :categoryId AND e.user.id = :userId AND e.deleted = FALSE")
-	List<Expense> findByCategoryIdAndUserId(@Param("categoryId") Long categoryId, @Param("userId") Long userId);}
+	List<Expense> findByCategoryIdAndUserIdAndExpenseDateBetweenAndDeletedFalse(Long categoryId, Long userId, LocalDateTime startDate, LocalDateTime endDate);
+
+	List<Expense> findByCategoryIdAndUserIdAndDeletedFalse(Long categoryId, Long userId);
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/expense/service/ExpenseServiceImpl.java
@@ -66,9 +66,18 @@ public class ExpenseServiceImpl implements ExpenseService {
 		Expense expense = expenseConverter.toExpenseEntity(expenseRequestDto, user, category);
 		expenseRepository.save(expense);
 
-		// 소비 목표 업데이트
-		consumptionGoalService.updateConsumeAmount(userId, expenseRequestDto.getCategoryId(),
-			expenseRequestDto.getAmount());
+		// expenseDate가 현재 월인지 확인
+		LocalDate expenseDateMonth = expenseRequestDto.getExpenseDate().toLocalDate().withDayOfMonth(1);
+		LocalDate currentMonth = LocalDate.now().withDayOfMonth(1);
+
+		if (expenseDateMonth.equals(currentMonth)) {
+			// 현재 월의 소비 내역일 경우 ConsumptionGoal을 업데이트
+			consumptionGoalService.updateConsumeAmount(userId, expenseRequestDto.getCategoryId(), expenseRequestDto.getAmount());
+		}
+//		else {
+//			// 과거 월의 소비 내역일 경우 해당 월의 ConsumptionGoal을 업데이트 또는 삭제 상태로 생성
+//			consumptionGoalService.updateOrCreateDeletedConsumptionGoal(userId, expenseRequestDto.getCategoryId(), expenseDateMonth, expenseRequestDto.getAmount());
+//		}
 
 		return expenseConverter.toExpenseResponseDto(expense);
         /*


### PR DESCRIPTION
## 개요
- category 삭제, 추가에 따른 과거의 expense, consumptionGoal 로직에 대한 오류 수정
- expense 삭제, 추가에 따른 과거의 consumptionGoal 로직에 대한 오류 수정

## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
