### PR TITLE
[refactor] 할인정보/지원정보 CRUD에 해시태그 엔티티 연동 및 해시태그 CRUD API 구현

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/domain/connectedinfo/repository/ConnectedInfoRepository.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/connectedinfo/repository/ConnectedInfoRepository.java
@@ -1,9 +1,19 @@
 package com.bbteam.budgetbuddies.domain.connectedinfo.repository;
 
 import com.bbteam.budgetbuddies.domain.connectedinfo.entity.ConnectedInfo;
+import com.bbteam.budgetbuddies.domain.discountinfo.entity.DiscountInfo;
+import com.bbteam.budgetbuddies.domain.supportinfo.entity.SupportInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface ConnectedInfoRepository extends JpaRepository<ConnectedInfo, Long> {
 
+    List<ConnectedInfo> findAllByDiscountInfo(DiscountInfo discountInfo);
 
+    void deleteAllByDiscountInfo(DiscountInfo discountInfo);
+
+    List<ConnectedInfo> findAllBySupportInfo(SupportInfo supportInfo);
+
+    void deleteAllBySupportInfo(SupportInfo supportInfo);
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/converter/DiscountInfoConverter.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/converter/DiscountInfoConverter.java
@@ -1,9 +1,14 @@
 package com.bbteam.budgetbuddies.domain.discountinfo.converter;
 
+import com.bbteam.budgetbuddies.domain.connectedinfo.entity.ConnectedInfo;
 import com.bbteam.budgetbuddies.domain.discountinfo.dto.DiscountRequest;
 import com.bbteam.budgetbuddies.domain.discountinfo.dto.DiscountResponseDto;
 import com.bbteam.budgetbuddies.domain.discountinfo.entity.DiscountInfo;
+import com.bbteam.budgetbuddies.domain.hashtag.entity.Hashtag;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class DiscountInfoConverter {
@@ -12,19 +17,27 @@ public class DiscountInfoConverter {
      * @param entity
      * @return responseDto
      */
-    public DiscountResponseDto toDto(DiscountInfo entity) {
+    public DiscountResponseDto toDto(DiscountInfo discountInfo, List<ConnectedInfo> connectedInfos) {
+        // 특정 할인정보의 해시태그 가져오기
+        List<String> hashtags = connectedInfos.stream()
+            .filter(connectedInfo -> connectedInfo.getDiscountInfo() != null && connectedInfo.getDiscountInfo().equals(discountInfo)) // 특정 DiscountInfo와 연결된 ConnectedInfo만 필터링
+            .map(ConnectedInfo::getHashtag)
+            .map(Hashtag::getName)
+            .collect(Collectors.toList());
 
         return DiscountResponseDto.builder()
-            .id(entity.getId())
-            .title(entity.getTitle())
-            .startDate(entity.getStartDate())
-            .endDate(entity.getEndDate())
-            .anonymousNumber(entity.getAnonymousNumber())
-            .discountRate(entity.getDiscountRate())
-            .likeCount(entity.getLikeCount())
-            .siteUrl(entity.getSiteUrl())
-            .thumbnailUrl(entity.getThumbnailUrl())
+            .id(discountInfo.getId())
+            .title(discountInfo.getTitle())
+            .startDate(discountInfo.getStartDate())
+            .endDate(discountInfo.getEndDate())
+            .anonymousNumber(discountInfo.getAnonymousNumber())
+            .discountRate(discountInfo.getDiscountRate())
+            .likeCount(discountInfo.getLikeCount())
+            .siteUrl(discountInfo.getSiteUrl())
+            .thumbnailUrl(discountInfo.getThumbnailUrl())
+            .hashtags(hashtags)
             .build();
+
     }
 
     /**
@@ -43,7 +56,7 @@ public class DiscountInfoConverter {
             .likeCount(0)
             .siteUrl(requestDto.getSiteUrl())
             .thumbnailUrl(requestDto.getThumbnailUrl())
-                .isInCalendar(requestDto.getIsInCalendar())
+            .isInCalendar(requestDto.getIsInCalendar())
             .build();
     }
 

--- a/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/dto/DiscountRequest.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/dto/DiscountRequest.java
@@ -3,6 +3,7 @@ package com.bbteam.budgetbuddies.domain.discountinfo.dto;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class DiscountRequest {
 
@@ -25,6 +26,8 @@ public class DiscountRequest {
         private String thumbnailUrl;
 
         private Boolean isInCalendar;
+
+        private List<Long> hashtagIds;
 
     }
 
@@ -49,6 +52,9 @@ public class DiscountRequest {
         private String thumbnailUrl;
 
         private Boolean isInCalendar;
+
+        private List<Long> hashtagIds;
+
     }
 
 

--- a/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/dto/DiscountResponseDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/dto/DiscountResponseDto.java
@@ -1,8 +1,10 @@
 package com.bbteam.budgetbuddies.domain.discountinfo.dto;
 
+import com.bbteam.budgetbuddies.domain.hashtag.entity.Hashtag;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Builder
@@ -27,5 +29,7 @@ public class DiscountResponseDto {
     private String siteUrl;
 
     private String thumbnailUrl;
+
+    private List<String> hashtags;
 
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/service/DiscountInfoServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/discountinfo/service/DiscountInfoServiceImpl.java
@@ -1,5 +1,7 @@
 package com.bbteam.budgetbuddies.domain.discountinfo.service;
 
+import com.bbteam.budgetbuddies.domain.connectedinfo.entity.ConnectedInfo;
+import com.bbteam.budgetbuddies.domain.connectedinfo.repository.ConnectedInfoRepository;
 import com.bbteam.budgetbuddies.domain.discountinfo.converter.DiscountInfoConverter;
 import com.bbteam.budgetbuddies.domain.discountinfo.dto.DiscountRequest;
 import com.bbteam.budgetbuddies.domain.discountinfo.dto.DiscountResponseDto;
@@ -7,6 +9,8 @@ import com.bbteam.budgetbuddies.domain.discountinfo.entity.DiscountInfo;
 import com.bbteam.budgetbuddies.domain.discountinfo.repository.DiscountInfoRepository;
 import com.bbteam.budgetbuddies.domain.discountinfolike.entity.DiscountInfoLike;
 import com.bbteam.budgetbuddies.domain.discountinfolike.repository.DiscountInfoLikeRepository;
+import com.bbteam.budgetbuddies.domain.hashtag.entity.Hashtag;
+import com.bbteam.budgetbuddies.domain.hashtag.repository.HashtagRepository;
 import com.bbteam.budgetbuddies.domain.user.entity.User;
 import com.bbteam.budgetbuddies.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -31,15 +36,19 @@ public class DiscountInfoServiceImpl implements DiscountInfoService {
 
     private final UserRepository userRepository;
 
+    private final HashtagRepository hashtagRepository;
+
+    private final ConnectedInfoRepository connectedInfoRepository;
 
     @Transactional(readOnly = true)
     @Override
     public Page<DiscountResponseDto> getDiscountsByYearAndMonth(Integer year, Integer month, Integer page, Integer size) {
         /**
-         * 1. Pageable 객체 생성 (사용자로부터 입력받은 page 번호와 size)
-         * 2. 사용자가 요청한 년월을 기준으로 해당 년월의 1일로 LocalDate 객체 생성
-         * 3. 해당 년월에 겹치는 할인정보 데이터 가져오기
-         * 4. Entity 리스트를 -> Dto로 모두 변환하여 리턴
+         * 1. Pageable 객체 생성: 사용자가 요청한 페이지 번호와 사이즈를 기반으로 Pageable 객체를 생성합니다.
+         * 2. 사용자가 요청한 년월에 해당하는 LocalDate 객체 생성: 해당 월의 첫날과 마지막 날을 기준으로 LocalDate 객체를 생성합니다.
+         * 3. 해당 년월에 겹치는 할인정보 데이터 가져오기: Repository를 사용하여 해당 월에 포함되는 할인정보를 페이지네이션하여 가져옵니다.
+         * 4. DiscountInfo 엔티티를 통해 ConnectedInfo 리스트 가져오기: 각 DiscountInfo에 대해 연결된 ConnectedInfo 리스트를 가져옵니다.
+         * 5. DiscountInfo와 ConnectedInfo 리스트를 Dto로 변환하여 리턴: 모든 데이터를 DTO로 변환하여 반환합니다.
          */
         Pageable pageable = PageRequest.of(page, size);
 
@@ -48,38 +57,55 @@ public class DiscountInfoServiceImpl implements DiscountInfoService {
 
         Page<DiscountInfo> discountInfoPage = discountInfoRepository.findByDateRange(startDate, endDate, pageable);
 
-        return discountInfoPage.map(discountInfoConverter::toDto);
+        return discountInfoPage.map(
+            discountInfo -> {
+                List<ConnectedInfo> connectedInfos = connectedInfoRepository.findAllByDiscountInfo(discountInfo);
+                return discountInfoConverter.toDto(discountInfo, connectedInfos);
+            }
+        );
     }
 
     @Transactional
     @Override
     public DiscountResponseDto registerDiscountInfo(DiscountRequest.RegisterDiscountDto discountRequestDto) {
         /**
-         * 1. RequestDto -> Entity로 변환
-         * 2. Entity 저장
-         * 3. Entity -> ResponseDto로 변환 후 리턴
+         * 1. RequestDto를 Entity로 변환: 입력받은 DTO를 DiscountInfo 엔티티로 변환합니다.
+         * 2. Entity 저장: 변환된 엔티티를 Repository를 통해 데이터베이스에 저장합니다.
+         * 3. Hashtag 엔티티 조회 및 연결: 입력받은 해시태그 ID 리스트를 사용하여 Hashtag 엔티티를 조회하고, 각 해시태그와 DiscountInfo를 연결하는 ConnectedInfo 엔티티를 생성하여 저장합니다.
+         * 4. ConnectedInfo 리스트 조회: 저장된 DiscountInfo와 관련된 ConnectedInfo 리스트를 조회합니다.
+         * 5. Entity를 ResponseDto로 변환하여 반환: 저장된 DiscountInfo와 관련된 ConnectedInfo 리스트를 포함한 DTO를 반환합니다.
          */
         DiscountInfo entity = discountInfoConverter.toEntity(discountRequestDto);
 
         discountInfoRepository.save(entity);
 
-        return discountInfoConverter.toDto(entity);
+        List<Hashtag> hashtags = hashtagRepository.findByIdIn(discountRequestDto.getHashtagIds());
+        hashtags.forEach(hashtag -> {
+            ConnectedInfo connectedInfo = ConnectedInfo.builder()
+                .discountInfo(entity)
+                .hashtag(hashtag)
+                .build();
+            connectedInfoRepository.save(connectedInfo);
+        });
+
+        List<ConnectedInfo> connectedInfos = connectedInfoRepository.findAllByDiscountInfo(entity);
+        return discountInfoConverter.toDto(entity, connectedInfos);
     }
 
     @Transactional
     @Override
     public DiscountResponseDto toggleLike(Long userId, Long discountInfoId) {
         /**
-         * 1. 사용자 조회 -> 없으면 에러
-         * 2. 할인정보 조회 -> 없으면 에러
-         * 3. 사용자가 특정 할인정보에 좋아요를 눌렀는지 확인 (DiscountInfoLike 테이블에서 userId로부터 데이터 가져오기)
-         * 4. 누르지 않은 상태라면,
-         *      4-1. DiscountInfo의 likeCount 1 증가
-         *      4-2. DiscountInfoLike의
-         * 5. 이미 누른 상태라면,
-         *      5-1. DiscountInfo의 likeCount 1 감소
+         * 1. 사용자 조회: 주어진 userId로 User 엔티티를 조회하며, 존재하지 않을 경우 에러를 발생시킵니다.
+         * 2. 할인정보 조회: 주어진 discountInfoId로 DiscountInfo 엔티티를 조회하며, 존재하지 않을 경우 에러를 발생시킵니다.
+         * 3. 사용자가 특정 할인정보에 좋아요를 눌렀는지 확인: DiscountInfoLike 테이블을 통해 사용자가 해당 할인정보에 좋아요를 눌렀는지 확인합니다.
+         * 4. 좋아요 상태에 따라 처리:
+         *    - 이미 좋아요를 누른 경우: 좋아요 상태를 변경하고, DiscountInfo의 likeCount를 감소시킵니다.
+         *    - 좋아요를 누르지 않은 경우: 좋아요 상태를 변경하고, DiscountInfo의 likeCount를 증가시킵니다.
+         * 5. 새 좋아요 객체 생성: 좋아요가 처음 생성된 경우 새로운 DiscountInfoLike 객체를 생성하고 저장합니다.
+         * 6. 저장된 DiscountInfo와 관련된 ConnectedInfo 리스트 조회: 업데이트된 DiscountInfo와 연결된 ConnectedInfo 리스트를 조회합니다.
+         * 7. Entity를 ResponseDto로 변환하여 반환: 최종적으로 업데이트된 DiscountInfo와 관련된 ConnectedInfo 리스트를 포함한 DTO를 반환합니다.
          */
-
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
@@ -100,7 +126,7 @@ public class DiscountInfoServiceImpl implements DiscountInfoService {
                 discountInfo.addLikeCount();
             }
         } else {
-            // 처음 객체를 생성한다면
+            // 아직 좋아요를 누르지 않은 상태라면
             DiscountInfoLike newLike = DiscountInfoLike.builder()
                 .user(user)
                 .discountInfo(discountInfo)
@@ -112,20 +138,21 @@ public class DiscountInfoServiceImpl implements DiscountInfoService {
 
         DiscountInfo savedEntity = discountInfoRepository.save(discountInfo);
 
-        return discountInfoConverter.toDto(savedEntity);
+        List<ConnectedInfo> connectedInfos = connectedInfoRepository.findAllByDiscountInfo(discountInfo);
+
+        return discountInfoConverter.toDto(savedEntity, connectedInfos);
     }
 
     @Transactional
     @Override
     public DiscountResponseDto updateDiscountInfo(DiscountRequest.UpdateDiscountDto discountRequestDto) {
         /**
-         * 1. 할인정보 조회 -> 없으면 에러
-         * 2. 변경사항 업데이트
-         * 3. 변경사항 저장
-         * 4. Entity -> ResponseDto로 변환 후 리턴
+         * 1. 할인정보 조회: 주어진 discountRequestDto의 ID로 DiscountInfo 엔티티를 조회하며, 존재하지 않을 경우 에러를 발생시킵니다.
+         * 2. 변경사항 업데이트: 조회된 DiscountInfo 엔티티에 대해 DTO에서 전달된 변경사항을 업데이트합니다.
+         * 3. 변경사항 저장: 업데이트된 DiscountInfo 엔티티를 데이터베이스에 저장합니다.
+         * 4. 저장된 DiscountInfo와 관련된 ConnectedInfo 리스트 조회: 업데이트된 DiscountInfo와 연결된 ConnectedInfo 리스트를 조회합니다.
+         * 5. Entity를 ResponseDto로 변환하여 반환: 업데이트된 DiscountInfo와 관련된 ConnectedInfo 리스트를 포함한 DTO를 반환합니다.
          */
-
-
         DiscountInfo discountInfo = discountInfoRepository.findById(discountRequestDto.getId())
             .orElseThrow(() -> new IllegalArgumentException("DiscountInfo not found"));
 
@@ -133,39 +160,45 @@ public class DiscountInfoServiceImpl implements DiscountInfoService {
 
         discountInfoRepository.save(discountInfo); // 변경사항 저장
 
-        return discountInfoConverter.toDto(discountInfo);
+        List<ConnectedInfo> connectedInfos = connectedInfoRepository.findAllByDiscountInfo(discountInfo);
+
+        return discountInfoConverter.toDto(discountInfo, connectedInfos);
     }
 
     @Transactional
     @Override
     public String deleteDiscountInfo(Long discountInfoId) {
         /**
-         * 1. 할인정보 조회 -> 없으면 에러
-         * 2. Entity 삭제
-         * 3. 성공여부 반환
+         * 1. 할인정보 조회: 주어진 discountInfoId로 DiscountInfo 엔티티를 조회하며, 존재하지 않을 경우 에러를 발생시킵니다.
+         * 2. 연관된 ConnectedInfo 삭제: 연결된 모든 ConnectedInfo를 삭제하여 연관된 데이터를 제거합니다.
+         * 3. DiscountInfo 삭제: DiscountInfo 엔티티를 데이터베이스에서 삭제합니다.
+         * 4. 성공 여부 반환: 삭제 작업이 완료된 후 "Success"를 반환합니다.
          */
-
         DiscountInfo discountInfo = discountInfoRepository.findById(discountInfoId)
             .orElseThrow(() -> new IllegalArgumentException("DiscountInfo not found"));
 
+        // 연결된 ConnectedInfo 삭제 (일단 삭제되지 않도록 주석 처리)
+//        connectedInfoRepository.deleteAllByDiscountInfo(discountInfo);
+
+        // DiscountInfo 삭제
         discountInfoRepository.deleteById(discountInfoId);
 
         return "Success";
-
     }
 
     @Transactional
     @Override
     public DiscountResponseDto getDiscountInfoById(Long discountInfoId) {
         /**
-         * 1. 할인정보 조회 -> 없으면 에러
-         * 2. Entity 조회
-         * 3. Entity -> ResponseDto로 변환 후 리턴
+         * 1. 할인정보 조회: 주어진 discountInfoId로 DiscountInfo 엔티티를 조회하며, 존재하지 않을 경우 에러를 발생시킵니다.
+         * 2. Entity 조회: 조회된 DiscountInfo와 관련된 ConnectedInfo 리스트를 가져옵니다.
+         * 3. Entity를 ResponseDto로 변환하여 반환: DiscountInfo와 관련된 ConnectedInfo 리스트를 포함한 DTO를 반환합니다.
          */
-
         DiscountInfo discountInfo = discountInfoRepository.findById(discountInfoId)
             .orElseThrow(() -> new IllegalArgumentException("DiscountInfo not found"));
 
-        return discountInfoConverter.toDto(discountInfo);
+        List<ConnectedInfo> connectedInfos = connectedInfoRepository.findAllByDiscountInfo(discountInfo);
+
+        return discountInfoConverter.toDto(discountInfo, connectedInfos);
     }
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/controller/HashtagApi.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/controller/HashtagApi.java
@@ -1,0 +1,75 @@
+package com.bbteam.budgetbuddies.domain.hashtag.controller;
+
+import com.bbteam.budgetbuddies.apiPayload.ApiResponse;
+import com.bbteam.budgetbuddies.domain.hashtag.dto.HashtagRequest;
+import com.bbteam.budgetbuddies.domain.hashtag.dto.HashtagResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+public interface HashtagApi {
+
+    @Operation(summary = "[User] 모든 해시태그 리스트 가져오기 API", description = "해시태그 목록을 조회하는 API입니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<List<HashtagResponse>> getAllHashtag();
+
+    @Operation(summary = "[ADMIN] 해시태그 등록하기 API", description = "해시태그를 등록하는 API이며, 관리자만 접근 가능합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<HashtagResponse> registerHashtag(
+        @RequestBody HashtagRequest.RegisterHashtagDto registerHashtagDto
+    );
+
+    @Operation(summary = "[ADMIN] 특정 해시태그 수정하기 API", description = "특정 해시태그를 수정하는 API입니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<HashtagResponse> updateHashtag(
+        @RequestBody HashtagRequest.UpdateHashtagDto updateHashtagDto
+    );
+
+    @Operation(summary = "[ADMIN] 특정 해시태그 삭제하기 API", description = "ID를 통해 특정 해시태그를 삭제하는 API입니다. 해시태그 삭제 시 연관된 지원정보 및 할인정보에 표시되지 않습니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @Parameters({
+        @Parameter(name = "hashtagId", description = "삭제할 해시태그의 id입니다."),
+    })
+    ApiResponse<String> deleteHashtag(
+        @PathVariable Long hashtagId
+    );
+
+    @Operation(summary = "[ADMIN] 특정 해시태그 가져오기 API", description = "ID를 통해 특정 해시태그를 가져오는 API입니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+//        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @Parameters({
+        @Parameter(name = "hashtagId", description = "조회할 해시태그의 id입니다."),
+    })
+    ApiResponse<HashtagResponse> getHashtag(
+        @PathVariable Long hashtagId
+    );
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/controller/HashtagController.java
@@ -1,0 +1,69 @@
+package com.bbteam.budgetbuddies.domain.hashtag.controller;
+
+import com.bbteam.budgetbuddies.apiPayload.ApiResponse;
+import com.bbteam.budgetbuddies.domain.hashtag.dto.HashtagRequest;
+import com.bbteam.budgetbuddies.domain.hashtag.dto.HashtagResponse;
+import com.bbteam.budgetbuddies.domain.hashtag.service.HashtagService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/hashtags")
+public class HashtagController implements HashtagApi {
+
+    private final HashtagService hashtagService;
+
+    @Override
+    @GetMapping("/find-all")
+    public ApiResponse<List<HashtagResponse>> getAllHashtag() {
+
+        List<HashtagResponse> hashtagResponses = hashtagService.getAllHashtag();
+
+        return ApiResponse.onSuccess(hashtagResponses);
+    }
+
+    @Override
+    @PostMapping("")
+    public ApiResponse<HashtagResponse> registerHashtag(
+        @RequestBody HashtagRequest.RegisterHashtagDto registerHashtagDto
+    ) {
+
+        HashtagResponse hashtagResponse = hashtagService.registerHashtag(registerHashtagDto);
+
+        return ApiResponse.onSuccess(hashtagResponse);
+    }
+
+    @Override
+    @PutMapping("")
+    public ApiResponse<HashtagResponse> updateHashtag(
+        @RequestBody HashtagRequest.UpdateHashtagDto updateHashtagDto
+    ) {
+
+        HashtagResponse hashtagResponse = hashtagService.updateHashtag(updateHashtagDto);
+
+        return ApiResponse.onSuccess(hashtagResponse);
+    }
+
+    @Override
+    @DeleteMapping("/{hashtagId}")
+    public ApiResponse<String> deleteHashtag(
+        @PathVariable Long hashtagId
+    ) {
+        String message = hashtagService.deleteHashtag(hashtagId);
+
+        return ApiResponse.onSuccess(message);
+    }
+
+    @Override
+    @GetMapping("/{hashtagId}")
+    public ApiResponse<HashtagResponse> getHashtag(
+        @PathVariable Long hashtagId
+    ) {
+        HashtagResponse hashtagResponse = hashtagService.getHashtagById(hashtagId);
+
+        return ApiResponse.onSuccess(hashtagResponse);
+    }
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/converter/HashtagConverter.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/converter/HashtagConverter.java
@@ -1,0 +1,37 @@
+package com.bbteam.budgetbuddies.domain.hashtag.converter;
+
+import com.bbteam.budgetbuddies.domain.hashtag.dto.HashtagRequest;
+import com.bbteam.budgetbuddies.domain.hashtag.dto.HashtagResponse;
+import com.bbteam.budgetbuddies.domain.hashtag.entity.Hashtag;
+import org.springframework.stereotype.Service;
+
+@Service
+public class HashtagConverter {
+
+    /**
+     * @param entity
+     * @return responseDto
+     */
+
+    public HashtagResponse toDto(Hashtag hashtag) {
+
+        return HashtagResponse.builder()
+            .id(hashtag.getId())
+            .name(hashtag.getName())
+            .build();
+
+    }
+
+    /**
+     * @param requestDto
+     * @return entity
+     */
+    public Hashtag toEntity(HashtagRequest.RegisterHashtagDto registerHashtagDto) {
+
+        return Hashtag.builder()
+            .name(registerHashtagDto.getName())
+            .build();
+
+    }
+
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/dto/HashtagRequest.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/dto/HashtagRequest.java
@@ -1,0 +1,34 @@
+package com.bbteam.budgetbuddies.domain.hashtag.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+public class HashtagRequest {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RegisterHashtagDto {
+
+        private String name;
+
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateHashtagDto {
+
+        private Long id;
+
+        private String name;
+
+    }
+
+
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/dto/HashtagResponse.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/dto/HashtagResponse.java
@@ -1,0 +1,18 @@
+package com.bbteam.budgetbuddies.domain.hashtag.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HashtagResponse {
+
+    private Long id;
+
+    private String name;
+
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/entity/Hashtag.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/entity/Hashtag.java
@@ -1,6 +1,7 @@
 package com.bbteam.budgetbuddies.domain.hashtag.entity;
 
 import com.bbteam.budgetbuddies.common.BaseEntity;
+import com.bbteam.budgetbuddies.domain.hashtag.dto.HashtagRequest;
 import jakarta.persistence.Entity;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -14,5 +15,9 @@ import lombok.experimental.SuperBuilder;
 public class Hashtag extends BaseEntity {
 
     private String name; // 해시태그 이름
+
+    public void update(HashtagRequest.UpdateHashtagDto updateHashtagDto) {
+        this.name = updateHashtagDto.getName();
+    }
 
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/repository/HashtagRepository.java
@@ -3,7 +3,11 @@ package com.bbteam.budgetbuddies.domain.hashtag.repository;
 import com.bbteam.budgetbuddies.domain.hashtag.entity.Hashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
 
+    // 해시태그 아이디를 기반으로 해시태그 엔티티 가져오기
+    List<Hashtag> findByIdIn(List<Long> hashtagIds);
 
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/service/HashtagService.java
@@ -1,0 +1,21 @@
+package com.bbteam.budgetbuddies.domain.hashtag.service;
+
+
+import com.bbteam.budgetbuddies.domain.hashtag.dto.HashtagRequest;
+import com.bbteam.budgetbuddies.domain.hashtag.dto.HashtagResponse;
+
+import java.util.List;
+
+public interface HashtagService {
+
+    List<HashtagResponse> getAllHashtag();
+
+    HashtagResponse registerHashtag(HashtagRequest.RegisterHashtagDto registerHashtagDto);
+
+    HashtagResponse updateHashtag(HashtagRequest.UpdateHashtagDto updateHashtagDto);
+
+    String deleteHashtag(Long hashtagId);
+
+    HashtagResponse getHashtagById(Long hashtagId);
+
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/hashtag/service/HashtagServiceImpl.java
@@ -1,0 +1,94 @@
+package com.bbteam.budgetbuddies.domain.hashtag.service;
+
+import com.bbteam.budgetbuddies.domain.hashtag.converter.HashtagConverter;
+import com.bbteam.budgetbuddies.domain.hashtag.dto.HashtagRequest;
+import com.bbteam.budgetbuddies.domain.hashtag.dto.HashtagResponse;
+import com.bbteam.budgetbuddies.domain.hashtag.entity.Hashtag;
+import com.bbteam.budgetbuddies.domain.hashtag.repository.HashtagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HashtagServiceImpl implements HashtagService {
+
+    private final HashtagRepository hashtagRepository;
+
+    private final HashtagConverter hashtagConverter;
+
+    @Transactional
+    @Override
+    public List<HashtagResponse> getAllHashtag() {
+        /**
+         * 모든 해시태그를 찾아 리스트로 리턴합니다.
+          */
+
+        List<Hashtag> hashtags = hashtagRepository.findAll();
+
+        return hashtags.stream()
+            .map(hashtagConverter::toDto)
+            .toList();
+    }
+
+    @Transactional
+    @Override
+    public HashtagResponse registerHashtag(HashtagRequest.RegisterHashtagDto registerHashtagDto) {
+        /**
+         * 해시태그를 등록합니다.
+         */
+
+        Hashtag hashtag = hashtagConverter.toEntity(registerHashtagDto);
+
+        hashtagRepository.save(hashtag);
+
+        return hashtagConverter.toDto(hashtag);
+    }
+
+    @Transactional
+    @Override
+    public HashtagResponse updateHashtag(HashtagRequest.UpdateHashtagDto updateHashtagDto) {
+        /**
+         * 해시태그 이름을 수정합니다.
+         */
+
+        Hashtag hashtag = hashtagRepository.findById(updateHashtagDto.getId())
+            .orElseThrow(() -> new IllegalArgumentException("Hashtag not found"));
+
+        hashtag.update(updateHashtagDto);
+
+        hashtagRepository.save(hashtag);
+
+        return hashtagConverter.toDto(hashtag);
+    }
+
+    @Transactional
+    @Override
+    public String deleteHashtag(Long hashtagId) {
+        /**
+         * 해시태그를 삭제합니다.
+         */
+
+        Hashtag hashtag = hashtagRepository.findById(hashtagId)
+            .orElseThrow(() -> new IllegalArgumentException("Hashtag not found"));
+
+        hashtagRepository.deleteById(hashtagId);
+
+        return "Success";
+    }
+
+    @Transactional
+    @Override
+    public HashtagResponse getHashtagById(Long hashtagId) {
+        /**
+         * 특정 해시태그를 하나 조회합니다.
+         */
+
+        Hashtag hashtag = hashtagRepository.findById(hashtagId)
+            .orElseThrow(() -> new IllegalArgumentException("Hashtag not found"));
+        
+        return hashtagConverter.toDto(hashtag);
+    }
+}

--- a/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/converter/SupportInfoConverter.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/converter/SupportInfoConverter.java
@@ -1,9 +1,14 @@
 package com.bbteam.budgetbuddies.domain.supportinfo.converter;
 
+import com.bbteam.budgetbuddies.domain.connectedinfo.entity.ConnectedInfo;
+import com.bbteam.budgetbuddies.domain.hashtag.entity.Hashtag;
 import com.bbteam.budgetbuddies.domain.supportinfo.dto.SupportRequest;
 import com.bbteam.budgetbuddies.domain.supportinfo.dto.SupportResponseDto;
 import com.bbteam.budgetbuddies.domain.supportinfo.entity.SupportInfo;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class SupportInfoConverter {
@@ -11,17 +16,24 @@ public class SupportInfoConverter {
      * @param entity
      * @return responseDto
      */
-    public SupportResponseDto toDto(SupportInfo entity) {
+    public SupportResponseDto toDto(SupportInfo supportInfo, List<ConnectedInfo> connectedInfos) {
+        // 특정 지원정보의 해시태그 가져오기
+        List<String> hashtags = connectedInfos.stream()
+            .filter(connectedInfo -> connectedInfo.getSupportInfo() != null && connectedInfo.getSupportInfo().equals(supportInfo)) // 특정 SupportInfo와 연결된 ConnectedInfo만 필터링
+            .map(ConnectedInfo::getHashtag)
+            .map(Hashtag::getName)
+            .collect(Collectors.toList());
 
         return SupportResponseDto.builder()
-            .id(entity.getId())
-            .title(entity.getTitle())
-            .startDate(entity.getStartDate())
-            .endDate(entity.getEndDate())
-            .anonymousNumber(entity.getAnonymousNumber())
-            .likeCount(entity.getLikeCount())
-            .siteUrl(entity.getSiteUrl())
-            .thumbnailUrl(entity.getThumbnailUrl())
+            .id(supportInfo.getId())
+            .title(supportInfo.getTitle())
+            .startDate(supportInfo.getStartDate())
+            .endDate(supportInfo.getEndDate())
+            .anonymousNumber(supportInfo.getAnonymousNumber())
+            .likeCount(supportInfo.getLikeCount())
+            .siteUrl(supportInfo.getSiteUrl())
+            .thumbnailUrl(supportInfo.getThumbnailUrl())
+            .hashtags(hashtags)
             .build();
     }
 
@@ -40,7 +52,7 @@ public class SupportInfoConverter {
             .likeCount(0)
             .siteUrl(requestDto.getSiteUrl())
             .thumbnailUrl(requestDto.getThumbnailUrl())
-                .isInCalendar(requestDto.getIsInCalendar())
+            .isInCalendar(requestDto.getIsInCalendar())
             .build();
     }
 }

--- a/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/dto/SupportRequest.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/dto/SupportRequest.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 
 public class SupportRequest {
@@ -28,6 +29,7 @@ public class SupportRequest {
 
         private Boolean isInCalendar;
 
+        private List<Long> hashtagIds;
 
     }
 
@@ -51,6 +53,7 @@ public class SupportRequest {
 
         private Boolean isInCalendar;
 
+        private List<Long> hashtagIds;
 
     }
 

--- a/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/dto/SupportResponseDto.java
+++ b/src/main/java/com/bbteam/budgetbuddies/domain/supportinfo/dto/SupportResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Builder
@@ -28,5 +29,7 @@ public class SupportResponseDto {
     private String siteUrl;
 
     private String thumbnailUrl;
+
+    private List<String> hashtags;
 
 }

--- a/src/test/java/com/bbteam/budgetbuddies/domain/supportinfo/service/SupportInfoServiceTest.java
+++ b/src/test/java/com/bbteam/budgetbuddies/domain/supportinfo/service/SupportInfoServiceTest.java
@@ -1,5 +1,7 @@
 package com.bbteam.budgetbuddies.domain.supportinfo.service;
 
+import com.bbteam.budgetbuddies.domain.connectedinfo.repository.ConnectedInfoRepository;
+import com.bbteam.budgetbuddies.domain.hashtag.repository.HashtagRepository;
 import com.bbteam.budgetbuddies.domain.supportinfo.converter.SupportInfoConverter;
 import com.bbteam.budgetbuddies.domain.supportinfo.dto.SupportRequest;
 import com.bbteam.budgetbuddies.domain.supportinfo.dto.SupportResponseDto;
@@ -48,6 +50,12 @@ class SupportInfoServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private ConnectedInfoRepository connectedInfoRepository;
+
+    @Mock
+    private HashtagRepository hashtagRepository;
+
     @InjectMocks
     private SupportInfoServiceImpl supportInfoService;
 
@@ -79,9 +87,12 @@ class SupportInfoServiceTest {
         SupportResponseDto dto1 = new SupportResponseDto();
         SupportResponseDto dto2 = new SupportResponseDto();
 
+        when(connectedInfoRepository.findAllBySupportInfo(support1)).thenReturn(List.of());
+        when(connectedInfoRepository.findAllBySupportInfo(support2)).thenReturn(List.of());
+
         when(supportInfoRepository.findByDateRange(startDate, endDate, pageable)).thenReturn(supportPage);
-        when(supportInfoConverter.toDto(support1)).thenReturn(dto1);
-        when(supportInfoConverter.toDto(support2)).thenReturn(dto2);
+        when(supportInfoConverter.toDto(support1, List.of())).thenReturn(dto1);
+        when(supportInfoConverter.toDto(support2, List.of())).thenReturn(dto2);
 
         // when
         Page<SupportResponseDto> result = supportInfoService.getSupportsByYearAndMonth(2024, 7, 0, 10);
@@ -95,8 +106,8 @@ class SupportInfoServiceTest {
 
         // 3. 각 메소드가 1번씩만 호출되었는지 검증
         verify(supportInfoRepository, times(1)).findByDateRange(startDate, endDate, pageable);
-        verify(supportInfoConverter, times(1)).toDto(support1);
-        verify(supportInfoConverter, times(1)).toDto(support2);
+        verify(supportInfoConverter, times(1)).toDto(support1, List.of());
+        verify(supportInfoConverter, times(1)).toDto(support2, List.of());
     }
 
     @Test
@@ -129,7 +140,7 @@ class SupportInfoServiceTest {
 
         when(supportInfoConverter.toEntity(requestDto)).thenReturn(entity);
         when(supportInfoRepository.save(entity)).thenReturn(entity);
-        when(supportInfoConverter.toDto(entity)).thenReturn(responseDto);
+        when(supportInfoConverter.toDto(entity, List.of())).thenReturn(responseDto);
 
         // when
         SupportResponseDto result = supportInfoService.registerSupportInfo(requestDto);
@@ -141,7 +152,7 @@ class SupportInfoServiceTest {
         // 2. 각 메소드가 1번씩만 호출되었는지 검증
         verify(supportInfoConverter, times(1)).toEntity(requestDto);
         verify(supportInfoRepository, times(1)).save(entity);
-        verify(supportInfoConverter, times(1)).toDto(entity);
+        verify(supportInfoConverter, times(1)).toDto(entity, List.of());
     }
 
     @Test
@@ -187,11 +198,12 @@ class SupportInfoServiceTest {
             .siteUrl("http://example.com")
             .build();
 
+        when(connectedInfoRepository.findAllBySupportInfo(supportInfo)).thenReturn(List.of());
         when(supportInfoRepository.save(any(SupportInfo.class))).thenReturn(supportInfo);
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
         when(supportInfoRepository.findById(anyLong())).thenReturn(Optional.of(supportInfo));
         when(supportInfoLikeRepository.findByUserAndSupportInfo(user, supportInfo)).thenReturn(Optional.of(supportInfoLike));
-        when(supportInfoConverter.toDto(any(SupportInfo.class))).thenReturn(responseDto);
+        when(supportInfoConverter.toDto(any(SupportInfo.class), anyList())).thenReturn(responseDto);
 
         // when
         SupportResponseDto result = supportInfoService.toggleLike(1L, 1L);
@@ -206,7 +218,7 @@ class SupportInfoServiceTest {
         // 3. 각 메소드가 1번씩만 호출되었는지 검증
         verify(supportInfoRepository, times(1)).findById(1L);
         verify(supportInfoRepository, times(1)).save(supportInfo);
-        verify(supportInfoConverter, times(1)).toDto(supportInfo);
+        verify(supportInfoConverter, times(1)).toDto(supportInfo, List.of());
     }
 
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

1.  할인정보 CRUD에 해시태그 엔티티를 연동하여 연관된 해시태그를 함께 가져오도록 수정하였습니다.
2. 지원정보 CRUD에 해시태그 엔티티를 연동하여 연관된 해시태그를 함께 가져오도록 수정하였습니다.
3. 해시태그 CRUD API 구현하였습니다.
4. 할인정보 및 지원정보 테스트 코드를 위 변경사항에 맞게 수정하였습니다.


## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
