### PR TITLE
[feat] 휴대전화 인증 시 기존 사용자인지 여부 응답하도록 변경

### DIFF
--- a/src/main/java/com/bbteam/budgetbuddies/global/security/auth/dto/AuthenticationResponse.java
+++ b/src/main/java/com/bbteam/budgetbuddies/global/security/auth/dto/AuthenticationResponse.java
@@ -39,6 +39,9 @@ public class AuthenticationResponse {
         @Schema(description = "전화번호", example = "01012341234")
         private String phoneNumber; // 전화번호
 
+        @Schema(description = "기존에 회원가입했던 사용자: true / 첫 로그인하는 사용자: false")
+        private Boolean existingUser; // 기존에 회원가입했던 사용자: true / 첫 로그인하는 사용자: false
+
         @Schema(description = "액세스 토큰")
         private String accessToken; // 액세스 토큰
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
> 아래 플로우대로 진행하기 위해 사용자가 기존에 회원가입을 했던 사용자인지에 대한 여부를 전화번호 인증 완료 시 응답 메시지에 포함하여 전송하도록 변경합니다.

1. "시작하기" 버튼 -> 가입화면 (전화번호 인증 완료) -> 기본 정보, 추가 정보 입력화면 이동
2. "이미 계정이 있으신가요?" 로그인 버튼 -> 로그인 화면 (전화번호 인증 완료) -> 바로 앱 메인 화면 이동


## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
